### PR TITLE
Added mouse wheel navigation to options.

### DIFF
--- a/html/options.html
+++ b/html/options.html
@@ -51,6 +51,11 @@
                                     <label class="checkbox" for="chkShowHighRes"><input type="checkbox" id="chkShowHighRes"><span></span> Show high resolution pictures when available</label>
                                 </li>
                             </div>
+							<div class="ttip" data-tooltip="Navigate album with the mouse wheel">
+                                <li class="field">
+                                    <label class="checkbox" for="chkGalleriesMouseWheel"><input type="checkbox" id="chkGalleriesMouseWheel"><span></span> Use mousewheel to navigate albums</label>
+                                </li>
+                            </div>
                             <div class="ttip" data-tooltip="Zoom videos (WebM, MP4)">
                                 <li class="field">
                                     <label class="checkbox" for="chkZoomVideos"><input type="checkbox" id="chkZoomVideos"><span></span> Zoom videos (WebM, MP4)</label>

--- a/js/background.js
+++ b/js/background.js
@@ -125,6 +125,7 @@ function optionsStats() {
     _gaq.push(['_trackEvent', 'Options', 'mouseUnderlap', options.mouseUnderlap.toString()]);
     _gaq.push(['_trackEvent', 'Options', 'showCaptions', options.showCaptions.toString()]);
     _gaq.push(['_trackEvent', 'Options', 'showHighRes', options.showHighRes.toString()]);
+    _gaq.push(['_trackEvent', 'Options', 'galleriesMouseWheel', options.galleriesMouseWheel.toString()]);
     _gaq.push(['_trackEvent', 'Options', 'addToHistory', options.addToHistory.toString()]);
     _gaq.push(['_trackEvent', 'Options', 'alwaysPreload', options.alwaysPreload.toString()]);
     _gaq.push(['_trackEvent', 'Options', 'showWhileLoading', options.showWhileLoading.toString()]);

--- a/js/common.js
+++ b/js/common.js
@@ -13,6 +13,7 @@ function loadOptions() {
     options.pageActionEnabled = options.hasOwnProperty('pageActionEnabled') ? options.pageActionEnabled : true;
     options.showCaptions = options.hasOwnProperty('showCaptions') ? options.showCaptions : true;
     options.showHighRes = options.hasOwnProperty('showHighRes') ? options.showHighRes : false;
+	options.galleriesMouseWheel = options.hasOwnProperty('galleriesMouseWheel') ? options.galleriesMouseWheel : true;
     options.addToHistory = options.hasOwnProperty('addToHistory') ? options.addToHistory : false;
     options.alwaysPreload = options.hasOwnProperty('alwaysPreload') ? options.alwaysPreload : false;
     options.displayDelay = options.hasOwnProperty('displayDelay') ? options.displayDelay : 100;

--- a/js/options.js
+++ b/js/options.js
@@ -114,6 +114,7 @@ function saveOptions() {
     options.showCaptions = $('#chkShowCaptions')[0].checked;
     options.showWhileLoading = $('#chkShowWhileLoading')[0].checked;
     options.showHighRes = $('#chkShowHighRes')[0].checked;
+	options.galleriesMouseWheel = $('chkGalleriesMouseWheel')[0].checked;
     options.displayDelay = getMilliseconds($('#txtDisplayDelay'));
     options.fadeDuration = getMilliseconds($('#txtFadeDuration'));
 
@@ -154,6 +155,7 @@ function restoreOptions() {
     $('#chkShowCaptions')[0].checked = options.showCaptions;
     $('#chkShowWhileLoading')[0].checked = options.showWhileLoading;
     $('#chkShowHighRes')[0].checked = options.showHighRes;
+	$('#chkGalleriesMouseWheel')[0].checked = options.galleriesMouseWheel;
     $('#txtDisplayDelay').val((options.displayDelay || 0) / 1000);
     $('#txtFadeDuration').val((options.fadeDuration || 0) / 1000);
 


### PR DESCRIPTION
The code for navigation of albums with the mouse wheel was already supported, but there was no way to enable it via the options. I have added an entry for mouse wheel navigation in the options page.