### PR TITLE
Special case for StackOverflow custom domain

### DIFF
--- a/plugins/imgur_a.js
+++ b/plugins/imgur_a.js
@@ -11,7 +11,7 @@ hoverZoomPlugins.push({
             //return srcs.concat(srcs).concat(srcs).concat(srcs);
             return srcs;
         }
-        
+
         function htmlDecode(input){
             var e = document.createElement('div');
             e.innerHTML = input;
@@ -21,6 +21,14 @@ hoverZoomPlugins.push({
         function prepareImgLink() {
             var link = $(this), data = link.data(), href = link.attr('href');
             if (data.hoverZoomSrc || data.hoverZoomGallerySrc) {
+                return;
+            }
+
+            // special case for StackOverflow custom subdomain
+            if (-1 !== href.indexOf('i.stack.imgur.com')) {
+                data.hoverZoomSrc = [href.replace('http:', window.location.protocol)];
+                res.push(link);
+
                 return;
             }
 
@@ -36,7 +44,7 @@ hoverZoomPlugins.push({
                     if (excl.indexOf(hash) > -1) {
                         return;
                     }
-                    
+
                     switch (view) {
                         case 'signin':
                             return;


### PR DESCRIPTION
Following https://github.com/extesy/hoverzoom/pull/97, matching the custom domain for StackOverflow wasn't enough.
Since the `createUrls` force the domain to `i.imgur.com` photo from SO generate confusion.

For example, this url http://i.stack.imgur.com/sgKzK.jpg will be converted to http://i.imgur.com/sgKzK.jpg which is (definitely) not the same one (even if they have the same hash).

This PR fix that problem by handling that case.

_Sorry for not testing my previous PR._