### PR TITLE
Disabled youtube video preview in embeded iframe

### DIFF
--- a/plugins/youtube_a.js
+++ b/plugins/youtube_a.js
@@ -43,7 +43,7 @@ hoverZoomPlugins.push({
         }
 
         function prepareVideoPreview(link, id) {
-            if (link.hasClass('hoverZoomLoading') || link.hasClass('hoverZoomLink')) return;
+            if (link.hasClass('hoverZoomLoading') || link.hasClass('hoverZoomLink') || link.hasClass('ytp-title-link')) return;
             link.addClass('hoverZoomLoading');
 
             var match = link.attr('href').match(/[\?&]t=([\dhm]+)/);


### PR DESCRIPTION
Fixes #132. This is done by checking if the current link has the class
.ytp-title-link in prepareVideoPreview. I tested this change on a number
of ways, and it doesn't look like it breaks functionality anywhere.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/extesy/hoverzoom/176)
<!-- Reviewable:end -->
