### PR TITLE
Stop removing the title attribute

### DIFF
--- a/js/hoverzoom.js
+++ b/js/hoverzoom.js
@@ -289,7 +289,7 @@ var hoverZoom = {
             titledElements = $('[title]').not('iframe, .lightbox, [rel^="lightbox"]');
             titledElements.each(function () {
                 $(this).data().hoverZoomTitle = this.getAttribute('title');
-                this.removeAttribute('title');
+                this.title = '';
             });
         }
 


### PR DESCRIPTION
Fixes #110. Some websites use css selectors that require the
title-attribute to be present for the styling to work. Subreddits does
this a lot for flairs, and with this change we let websites keep styles
that are based on the title-attribute being present.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/extesy/hoverzoom/177)
<!-- Reviewable:end -->
