### PR TITLE
Fix of plugin: 1x

### DIFF
--- a/plugins/1x.js
+++ b/plugins/1x.js
@@ -1,7 +1,7 @@
 var hoverZoomPlugins = hoverZoomPlugins || [];
 hoverZoomPlugins.push({
     name:'1x.com',
-    version:'0.1',
+    version:'0.2',
     prepareImgLinks:function (callback) {
         var res = [];
         hoverZoom.urlReplace(res,
@@ -24,27 +24,27 @@ hoverZoomPlugins.push({
             '-thumb.',
             '-fullsize.'
         );
-		hoverZoom.urlReplace(res,
+        hoverZoom.urlReplace(res,
             'img[src]',
             '-ld.',
             '-hd2.'
         );
-		hoverZoom.urlReplace(res,
+        hoverZoom.urlReplace(res,
             'img[src]',
             '-ld.',
             '-sd.'
         );
-		hoverZoom.urlReplace(res,
+        hoverZoom.urlReplace(res,
             'img[src]',
             '-sq.',
             '-hd2.'
         );
-		hoverZoom.urlReplace(res,
+        hoverZoom.urlReplace(res,
             'img[src]',
             '-sq.',
             '-sd.'
         );
-		hoverZoom.urlReplace(res,
+        hoverZoom.urlReplace(res,
             'img[src]',
             '-square.',
             '.'

--- a/plugins/1x.js
+++ b/plugins/1x.js
@@ -24,6 +24,31 @@ hoverZoomPlugins.push({
             '-thumb.',
             '-fullsize.'
         );
+		hoverZoom.urlReplace(res,
+            'img[src]',
+            '-ld.',
+            '-hd2.'
+        );
+		hoverZoom.urlReplace(res,
+            'img[src]',
+            '-ld.',
+            '-sd.'
+        );
+		hoverZoom.urlReplace(res,
+            'img[src]',
+            '-sq.',
+            '-hd2.'
+        );
+		hoverZoom.urlReplace(res,
+            'img[src]',
+            '-sq.',
+            '-sd.'
+        );
+		hoverZoom.urlReplace(res,
+            'img[src]',
+            '-square.',
+            '.'
+        );
         callback($(res));
     }
 });

--- a/plugins/blogcdn.js
+++ b/plugins/blogcdn.js
@@ -1,7 +1,7 @@
 ﻿var hoverZoomPlugins = hoverZoomPlugins || [];
 hoverZoomPlugins.push({
     name:'BlogCdn',
-    version:'0.1',
+    version:'0.2',
     prepareImgLinks:function (callback) {
         var res = [];
         hoverZoom.urlReplace(res,
@@ -9,6 +9,7 @@ hoverZoomPlugins.push({
             [/_\d+x\d+\./, '_thumbnail'],
             ['.', '']
         );
+        hoverZoom.urlReplace(res, 'img[src]', /(http.*)(http.*)/ , '$2');
         callback($(res));
     }
 });


### PR DESCRIPTION
Hi

This is my first pull request for HoverZoom, and hopefully not the last :fearful:
I fixed the js plugin: 1x.js
Fix was tested on 1x.com, it should have no impact anywhere else since plugin is only loaded on "*://*.1x.com/*" urls (according to manifest).

I'm new to GitHub (and to js!), so:
- please double-check!  
- comments/advices warmly welcomed!

Have a nice day :smiley: 

Fix details:
Added new search patterns:
-ld.
-sd.
-hd2.
-sq.
-square.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/extesy/hoverzoom/179)
<!-- Reviewable:end -->
