### PR TITLE
Prevent hoverzooming from removing titles of all titled things.

### DIFF
--- a/js/hoverzoom.js
+++ b/js/hoverzoom.js
@@ -298,7 +298,7 @@ var hoverZoom = {
             titledElements = $('[title]').not('iframe, .lightbox, [rel^="lightbox"]');
             titledElements.each(function () {
                 $(this).data().hoverZoomTitle = this.getAttribute('title');
-                this.title = '';
+                $(this).title = '';
             });
         }
 


### PR DESCRIPTION
There was a typo.  `this` referred to all titledElements.  `$(this)` refers to only the hover-zoomed thing.