### PR TITLE
bug fixed for relative path double slashes

### DIFF
--- a/js/hoverzoom.js
+++ b/js/hoverzoom.js
@@ -394,16 +394,13 @@ var hoverZoom = {
                             var src = links.data().hoverZoomSrc[hoverZoomSrcIndex];
                             if (src.indexOf('http') !== 0) {
                                 if (src.indexOf('//') !== 0) {
-                                    if (src.indexOf('/') === 0) {
-                                        // Image has absolute path (starts with '/')
-                                        src = src.substr(1);
-                                    } else {
+                                    if (src.indexOf('/') !== 0) {
                                         // Image has relative path (doesn't start with '/')
                                         var path = window.location.pathname;
                                         path = path.substr(0, path.lastIndexOf('/') + 1);
                                         src = path + src;
                                     }
-                                    src = '//' + window.location.host + '/' + src;
+                                    src = '//' + window.location.host + src;
                                 }
                                 src = window.location.protocol + src;
                                 links.data().hoverZoomSrc[hoverZoomSrcIndex] = src;


### PR DESCRIPTION
Example: 
page url=http://example.com/path/index
image on page is in relative path URL: photo.jpg

Previously, hoverzoom will load http://example.com//path/photo.jpg
Note the double slashes in the image path.
Usually, this won't create any problems until there are cookies involved.
If a cookie is set under path "/path", a browser will not send the cookie when loading "//path/photo.jpg".

This commit fixes the bug.
