### PR TITLE
Fix some of addons.mozilla.org warnings

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -75,7 +75,7 @@ function onMessage(message, sender, callback) {
             });
             break;
         case 'openViewTab':
-            chrome.tabs.getSelected(null, function (currentTab) {
+            chrome.tabs.query({active: true}, function (currentTab) {
                 message.createData.index = currentTab.index;
                 if (!message.createData.active)
                     message.createData.index++;

--- a/js/background.js
+++ b/js/background.js
@@ -108,7 +108,7 @@ function showPageAction(tab) {
 function checkUpdate() {
     currVersion = 1;
     if ("app" in chrome) {
-        var currVersion = chrome.app.getDetails().version,
+        var currVersion = chrome.runtime.getManifest().version,
             prevVersion = localStorage.hzVersion;
         if (hasReleaseNotes && options.updateNotifications && currVersion != prevVersion && typeof prevVersion != 'undefined') {
             showUpdateNotification();

--- a/js/common.js
+++ b/js/common.js
@@ -61,7 +61,7 @@ function sendOptions(options) {
     // Send options to all tabs
     chrome.windows.getAll(null, function (windows) {
         for (var i = 0; i < windows.length; i++) {
-            chrome.tabs.getAllInWindow(windows[i].id, function (tabs) {
+            chrome.tabs.query({windowId: windows[i].id}, function (tabs) {
                 for (var j = 0; j < tabs.length; j++) {
                     chrome.tabs.sendMessage(tabs[j].id, request);
                 }

--- a/js/options.js
+++ b/js/options.js
@@ -290,7 +290,7 @@ $(function () {
     initActionKeys();
     i18n();
     chkWhiteListModeOnChange();
-    $("#version").text(chrome.i18n.getMessage("optFooterVersionCopyright", chrome.app.getDetails().version));
+    $("#version").text(chrome.i18n.getMessage("optFooterVersionCopyright", chrome.runtime.getManifest().version));
 
     $('#btnSave').click(saveOptions);
     $('#btnReset').click(restoreOptions);

--- a/js/popup.js
+++ b/js/popup.js
@@ -44,7 +44,7 @@ function askTabsPermissions() {
 }
 
 function setTabHook(options) {
-    chrome.tabs.getSelected(null, function (tab) {
+    chrome.tabs.query({active: true}, function (tab) {
         siteDomain = tab.url.split('/', 3)[2];
         $('#lblToggle').text(chrome.i18n.getMessage(options.whiteListMode ? 'popEnableForSite' : 'popDisableForSite', siteDomain));
         $('#chkExtensionDisabled')[0].checked = !options.extensionEnabled;


### PR DESCRIPTION
This PR fixes following warnings from #300 

1. "tabs.getAllInWindow" is deprecated or unimplemented
5. "app.getDetails" is deprecated or unimplemented
7. "tabs.getSelected" is deprecated or unimplemented
8. "app.getDetails" is deprecated or unimplemented
9. tabs.getSelected" is deprecated or unimplemented
