### PR TITLE
There is no such manifest key as `locale`

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -13,7 +13,6 @@
         "48": "images/icon48.png",
         "128": "images/icon128.png"
     },
-    "locale": "en",
     "default_locale": "en",
     "minimum_chrome_version": "22",
     "background": {


### PR DESCRIPTION
Neither Firefox, Chrome or Edge recognize `locale` manifest key.
In addition, it also displays red warning on Chrome.

* https://docs.microsoft.com/en-us/microsoft-edge/extensions/api-support/supported-manifest-keys
* https://developer.chrome.com/extensions/manifest
* https://developer.mozilla.org/en-US/Add-ons/WebExtensions/manifest.json

There is `default_locale` indeed, but no `locale`.