### PR TITLE
Replace Chrome specific runtime.getPackageDirectoryEntry()

### DIFF
--- a/js/options.js
+++ b/js/options.js
@@ -245,23 +245,24 @@ function onMessage(message, sender, callback) {
 }
 
 function getPlugins(callback) {
-    chrome.runtime.getPackageDirectoryEntry(function(root) {
-        root.getDirectory("plugins", {create: false}, function(pluginsdir) {
-            var reader = pluginsdir.createReader();
-            var entries = [];
-            var readEntries = function() {
-                reader.readEntries(function(results) {
-                    if (results.length) {
-                        entries = entries.concat(results.map(function(de){return de.name;}));
-                        readEntries();
-                    } else {
-                        callback(entries);
-                    }
-                });
-            };
-            readEntries();
-        });
-    });
+    const plugins = [];
+    const manifest = chrome.runtime.getManifest();
+
+    manifest.content_scripts.forEach(script => script.js.forEach((path) => {
+        // Path can look like this on Firefox
+        // 'moz-extension://d5438889-adf3-4ed5-89b3-caacec62961b/plugins/skyrock.js'
+        // or like this on Chrome
+        // 'plugins/skyrock.js'
+
+        const split = path.split('/');
+
+        if (split.includes('plugins')) {
+            plugins.push(split[split.length - 1]);
+        }
+    }));
+
+    plugins.sort();
+    callback(plugins);
 }
 
 function loadPlugins() {


### PR DESCRIPTION
`runtime.getPackageDirectoryEntry()` API method is available only on Chrome and it's missing on Firefox and Edge.

It means `getPlugins()` function in `options.js` is broken on Firefox. Nothing is shown in Options page under Plugins tab.

I've replaced it with analysis of `content_scripts` in manifest. It finds all plugins and in the end whole functionality is same as before. Except now it won't list orphaned plugins like those in #303 