### PR TITLE
Added wykop.pl plugin

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1457,6 +1457,10 @@
         {
             "js": ["plugins/drawcrowd.js"],
             "matches": ["*://*.drawcrowd.com/*"]
+        },
+        {
+            "js": ["plugins/wykop.js"],
+            "matches": ["*://*.wykop.pl/*"]
         }
    ]
 }

--- a/plugins/wykop.js
+++ b/plugins/wykop.js
@@ -1,0 +1,25 @@
+var hoverZoomPlugins = hoverZoomPlugins || [];
+hoverZoomPlugins.push({
+    name: 'wykop.pl',
+    version: '0.1',
+    prepareImgLinks(callback) {
+        const res = [];
+
+        $('div.media-content.video').each((i, item) => {
+            const a = $('a.ajax', item)[0];
+            const img = $('img.block.lazy', a)[0];
+            const data = $(img).data();
+
+            const url = a.href.match(/https?:\/\/(?:giant\.)?gfycat\.com\/([^.]+)(?:.+)?/);
+            if (url !== null) {
+                data.hoverZoomSrc = ['mp4', 'webm'].map(ext => `https://giant.gfycat.com/${url[1]}.${ext}`);
+            }
+
+            res.push($(img));
+        });
+
+        if (res.length > 0) {
+            callback($(res));
+        }
+    },
+});


### PR DESCRIPTION
wykop.pl is Polish social media website with over 5 million unique users visiting monthly.
This plugin allows for hoverzoom of "GFY" images (WEBM/MP4), because regular images and GIFs already work fine.

I swear it's my last issue or PR today :>