### PR TITLE
Instagram: use full-size image instead of the default one.

### DIFF
--- a/plugins/instagram.js
+++ b/plugins/instagram.js
@@ -7,7 +7,7 @@ hoverZoomPlugins.push({
             if (link.hasClass('hoverZoomLink'))
                 return;
             if (link.find('span.coreSpriteSidecarIconLarge').length === 0) {
-                link.data().hoverZoomSrc = [link.find('img').attr('src')];
+                link.data().hoverZoomSrc = [link.prop('href').replace(/[?]taken-by=.*$/, 'media?size=l')];
                 link.addClass('hoverZoomLink');
                 hoverZoom.displayPicFromElement(link);
             } else {


### PR DESCRIPTION
Use a trick that replaces the post URL with an easy to remember URL that automatically redirects to the full-size image, instead of the (inexplicably) low-rez one that Instagram uses.