### PR TITLE
Fixed loadNextGalleryImage() recursing infinitely on error

### DIFF
--- a/js/hoverzoom.js
+++ b/js/hoverzoom.js
@@ -1286,7 +1286,7 @@ var hoverZoom = {
         function loadNextGalleryImage() {
             clearTimeout(loadFullSizeImageTimeout);
             imgDetails.url = hz.currentLink.data().hoverZoomSrc[hz.currentLink.data().hoverZoomSrcIndex];
-            imgFullSize.on('load', nextGalleryImageOnLoad).on('error', loadNextGalleryImage).attr('src', imgDetails.url);
+            imgFullSize.on('load', nextGalleryImageOnLoad).on('error', imgFullSizeOnError).attr('src', imgDetails.url);
         }
 
         function nextGalleryImageOnLoad() {


### PR DESCRIPTION
In `rotateGalleryImg(rot)`, if the next `hoverZoomGallerySrc` element is an array of possible URLs to try,
`loadNextGalleryImage()` will recurse infinitely on error (i.e. when the URL it's trying to reach is invalid). When attaching handlers to `imgFullSize` in `loadNextGalleryImage()`, the error handler should probably be `imgFullSizeOnError` instead of recursing back into `loadNextGalleryImage`.