### PR TITLE
Update gfycat.js

### DIFF
--- a/plugins/gfycat.js
+++ b/plugins/gfycat.js
@@ -5,7 +5,7 @@ hoverZoomPlugins.push({
         $('a[href*="gfycat.com/"]').one('mouseenter', function() {
             var link = $(this),
                 gfyId = this.href.replace(/.*gfycat.com\/(gifs\/)?(detail\/)?(\w+).*/, '$3');
-            $.get('https://gfycat.com/cajax/get/' + gfyId, function (data) {
+            $.get('https://api.gfycat.com/v1/gfycats/' + gfyId, function (data) {
                 if (data && data.gfyItem) {
                     link.data().hoverZoomSrc = [options.zoomVideos ? data.gfyItem.webmUrl : data.gfyItem.gifUrl]
                     link.addClass('hoverZoomLink');


### PR DESCRIPTION
Updated the get URL from https://gfycat.com/cajax/get/ to https://api.gfycat.com/v1/gfycats/ (Kudos to @jason-e for supplying the new URL here: https://github.com/extesy/hoverzoom/issues/416#issue-385615809)