### PR TITLE
fix disable current site feature in popup

### DIFF
--- a/js/popup.js
+++ b/js/popup.js
@@ -44,7 +44,8 @@ function askTabsPermissions() {
 }
 
 function setTabHook(options) {
-    chrome.tabs.query({active: true}, function (tab) {
+    chrome.tabs.query({active: true, currentWindow: true}, function (tabArr) {
+        var tab = tabArr[0];
         siteDomain = tab.url.split('/', 3)[2];
         $('#lblToggle').text(chrome.i18n.getMessage(options.whiteListMode ? 'popEnableForSite' : 'popDisableForSite', siteDomain));
         $('#chkExtensionDisabled')[0].checked = !options.extensionEnabled;


### PR DESCRIPTION
This fixes issue #423 created by myself. Currently the code didn't account for multiple windows being opened and tabs.query returns an array, the code was not accounting for that