### PR TITLE
Handle v.redd.it videos reliably and support audio

### DIFF
--- a/plugins/reddit.js
+++ b/plugins/reddit.js
@@ -26,7 +26,14 @@ hoverZoomPlugins.push({
       }
     });
 
+    var imagesDone = false, videosDone = false;
     var res = [];
+
+    function done () {
+      if (imagesDone && videosDone) {
+        callback($(res));
+      }
+    }
 
     $('div[data-url*="//i.redd.it/"], div[data-url*="//i.reddituploads.com/"]').each(function () {
       var post = $(this);
@@ -38,21 +45,35 @@ hoverZoomPlugins.push({
         img.data('hoverZoomCaption', [title]);
         res.push(img);
       });
+
+      imagesDone = true;
+      done();
     });
 
     $('div[data-url*="//v.redd.it/"]').each(function () {
       var post = $(this);
       var link = post.attr('data-url');
       var title = post.find('a.title').text();
-      post.find('a.thumbnail,a.title').each(function () {
-        var img = $(this);
+      var links = [].slice.call(post.find('a.thumbnail,a.title'));
+      var linksDone = links.map(function () { return false; });
+
+      function linkDone (i) {
+        linksDone[i] = true;
+        if (linksDone.every(function (b) { return b; })) {
+          videosDone = true;
+          done();
+        }
+      }
+
+      links.forEach(function (a, i) {
+        var img = $(a);
 
         // Use /DASH_600_K as a default if for any reason the ajax request below doesn't find a valid link
         img.data('hoverZoomSrc', [link + '/DASH_600_K']);
         img.data('hoverZoomCaption', [title]);
 
         $.get(link + '/DASHPlaylist.mpd', function (xmlDoc) {
-          var highestRes = [].slice.call(xmlDoc.querySelectorAll('Representation'))
+          var highestRes = [].slice.call(xmlDoc.querySelectorAll('Representation[mimeType^="video"]'))
             .sort(function (r1, r2) {
               var w1 = parseInt(r1.getAttribute('width')), w2 = parseInt(r2.getAttribute('width'));
               return w1 > w2 ? -1 : (w1 < w2 ? 1 : 0);
@@ -62,12 +83,18 @@ hoverZoomPlugins.push({
           if (highestRes) {
             img.data('hoverZoomSrc', [link + '/' + highestRes.querySelector('BaseURL').textContent.trim()]);
           }
+
+          var audio = xmlDoc.querySelector('Representation[mimeType^="audio"'),
+              audioUrl = audio ? audio.querySelector('BaseURL') : undefined;
+          if (audioUrl) {
+            img.data('hoverZoomAudioSrc', [link + '/' + audioUrl.textContent.trim()]);
+          }
+
+          linkDone(i);
         });
 
         res.push(img);
       });
     });
-
-    callback($(res));
   }
 });

--- a/plugins/reddit.js
+++ b/plugins/reddit.js
@@ -46,8 +46,24 @@ hoverZoomPlugins.push({
       var title = post.find('a.title').text();
       post.find('a.thumbnail,a.title').each(function () {
         var img = $(this);
-        img.data('hoverZoomSrc', [link + '/DASH_600_K']); // link + '/DASH_4_8_M', link + '/DASH_2_4_M', link + '/DASH_1_2_M',
+
+        // Use /DASH_600_K as a default if for any reason the ajax request below doesn't find a valid link
+        img.data('hoverZoomSrc', [link + '/DASH_600_K']);
         img.data('hoverZoomCaption', [title]);
+
+        $.get(link + '/DASHPlaylist.mpd', function (xmlDoc) {
+          var highestRes = [].slice.call(xmlDoc.querySelectorAll('Representation'))
+            .sort(function (r1, r2) {
+              var w1 = parseInt(r1.getAttribute('width')), w2 = parseInt(r2.getAttribute('width'));
+              return w1 > w2 ? -1 : (w1 < w2 ? 1 : 0);
+            })
+            .find(function (repr) { return !!repr.querySelector('BaseURL'); });
+
+          if (highestRes) {
+            img.data('hoverZoomSrc', [link + '/' + highestRes.querySelector('BaseURL').textContent.trim()]);
+          }
+        });
+
         res.push(img);
       });
     });

--- a/plugins/reddit.js
+++ b/plugins/reddit.js
@@ -26,14 +26,7 @@ hoverZoomPlugins.push({
       }
     });
 
-    var imagesDone = false, videosDone = false;
-    var res = [];
-
-    function done () {
-      if (imagesDone && videosDone) {
-        callback($(res));
-      }
-    }
+    var promises = [];
 
     $('div[data-url*="//i.redd.it/"], div[data-url*="//i.reddituploads.com/"]').each(function () {
       var post = $(this);
@@ -43,58 +36,51 @@ hoverZoomPlugins.push({
         var img = $(this);
         img.data('hoverZoomSrc', [link]);
         img.data('hoverZoomCaption', [title]);
-        res.push(img);
+        promises.push(Promise.resolve(img));
       });
-
-      imagesDone = true;
-      done();
     });
 
     $('div[data-url*="//v.redd.it/"]').each(function () {
       var post = $(this);
       var link = post.attr('data-url');
       var title = post.find('a.title').text();
-      var links = [].slice.call(post.find('a.thumbnail,a.title'));
-      var linksDone = links.map(function () { return false; });
 
-      function linkDone (i) {
-        linksDone[i] = true;
-        if (linksDone.every(function (b) { return b; })) {
-          videosDone = true;
-          done();
-        }
-      }
-
-      links.forEach(function (a, i) {
-        var img = $(a);
+      post.find('a.thumbnail,a.title').each(function() {
+        var img = $(this);
 
         // Use /DASH_600_K as a default if for any reason the ajax request below doesn't find a valid link
         img.data('hoverZoomSrc', [link + '/DASH_600_K']);
         img.data('hoverZoomCaption', [title]);
 
-        $.get(link + '/DASHPlaylist.mpd', function (xmlDoc) {
-          var highestRes = [].slice.call(xmlDoc.querySelectorAll('Representation[mimeType^="video"]'))
-            .sort(function (r1, r2) {
-              var w1 = parseInt(r1.getAttribute('width')), w2 = parseInt(r2.getAttribute('width'));
-              return w1 > w2 ? -1 : (w1 < w2 ? 1 : 0);
+        promises.push(new Promise(function (resolve, reject) {
+          $.get(link + '/DASHPlaylist.mpd')
+            .done(function (xmlDoc) {
+              var highestRes = [].slice.call(xmlDoc.querySelectorAll('Representation[mimeType^="video"]'))
+                .sort(function (r1, r2) {
+                  var w1 = parseInt(r1.getAttribute('width')), w2 = parseInt(r2.getAttribute('width'));
+                  return w1 > w2 ? -1 : (w1 < w2 ? 1 : 0);
+                })
+                .find(function (repr) { return !!repr.querySelector('BaseURL'); });
+
+              if (highestRes) {
+                img.data('hoverZoomSrc', [link + '/' + highestRes.querySelector('BaseURL').textContent.trim()]);
+              }
+
+              var audio = xmlDoc.querySelector('Representation[mimeType^="audio"'),
+                audioUrl = audio ? audio.querySelector('BaseURL') : undefined;
+              if (audioUrl) {
+                img.data('hoverZoomAudioSrc', [link + '/' + audioUrl.textContent.trim()]);
+              }
+
+              resolve(img);
             })
-            .find(function (repr) { return !!repr.querySelector('BaseURL'); });
-
-          if (highestRes) {
-            img.data('hoverZoomSrc', [link + '/' + highestRes.querySelector('BaseURL').textContent.trim()]);
-          }
-
-          var audio = xmlDoc.querySelector('Representation[mimeType^="audio"'),
-              audioUrl = audio ? audio.querySelector('BaseURL') : undefined;
-          if (audioUrl) {
-            img.data('hoverZoomAudioSrc', [link + '/' + audioUrl.textContent.trim()]);
-          }
-
-          linkDone(i);
-        });
-
-        res.push(img);
+            .fail(function (err) { reject(err); });
+        }));
       });
     });
+
+    Promise.all(promises.map(function (p) {
+      return p.catch(function(err) { console.error('Error initializing reddit image', err); });
+    })).then(function (res) { callback($(res)); })
   }
 });


### PR DESCRIPTION
I've found that a lot of videos on v.redd.it won't load with hoverzoom because the URL `/DASH_600_K` doesn't exist for that video. This updates the code that handles getting video links to request the `DASHPlaylist.mpd` file, which contains info about the available video resolutions, and then choose the highest resolution.

Additionally, the `DASHPlaylist.mpd` will contain info about audio streams, when available, so I've added functionality to support playing audio from a separate source URL than the video. When a separate audio source is specified via the `hoverZoomAudioSrc` data key, an HTML `audio` element will be created along with the `video`, and their playbacks will be kept in sync.