### PR TITLE
Fix streamable

### DIFF
--- a/plugins/streamable_a.js
+++ b/plugins/streamable_a.js
@@ -5,7 +5,7 @@ hoverZoomPlugins.push({
         if (!options.zoomVideos) return;
         $('a[href*="//streamable.com/"]').one('mouseenter', function () {
             hoverZoom.prepareFromDocument($(this), this.href, function(doc) {
-                return doc.querySelector('source').getAttribute('src');
+                return doc.querySelector('video').getAttribute('src');
             });
         });
     }


### PR DESCRIPTION
Streamable videos (e.g. https://streamable.com/rq6ui) no longer have a `source` element, the source of the video is just on the `video` element.