### PR TITLE
Plugin for Hiptest.com tests attachments

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1247,6 +1247,10 @@
         {
             "js": ["plugins/9gag.js"],
             "matches": ["*://9gag.com/*"]
+        },
+        {
+            "js": ["plugins/hiptest.js"],
+            "matches": ["*://app.hiptest.com/*"]
         }
    ]
 }

--- a/plugins/hiptest.js
+++ b/plugins/hiptest.js
@@ -1,0 +1,13 @@
+var hoverZoomPlugins = hoverZoomPlugins || [];
+hoverZoomPlugins.push({
+    name:'hiptest',
+    version:'0.1',
+    prepareImgLinks:function (callback) {
+        var res = [];
+        hoverZoom.urlReplace(res,
+            'a[href*="attachments"]',
+            /(.*)/, '$1/'
+        );
+        callback($(res));
+    }
+});


### PR DESCRIPTION
This is a plugin to directly preview tests attachments in test on Hiptest.com
Those attachments are files served by a link to an url like: https://app.hiptest.com/projects/124207/scenarios/3020680/attachments/151499

I didn't find how to just tell Hoverzoom to use the links I found, so I added a dummy regex.
Why is the thumbnail url forced to be different from the original picture ?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/extesy/hoverzoom/442)
<!-- Reviewable:end -->
