### PR TITLE
#455: Fix for profile images on Twitter no longer loading

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "__MSG_extName__",
     "short_name": "__MSG_extShortName__",
-    "version": "1.0.136",
+    "version": "1.0.137",
     "description": "__MSG_extDescription__",
     "homepage_url": "https://github.com/extesy/hoverzoom/",
     "author": "Oleg Anashkin",
@@ -622,7 +622,8 @@
             "js": ["plugins/twimg.js"],
             "matches": [
                 "*://*.favstar.fm/*",
-                "*://*.tweetmeme.com/*"
+                "*://*.tweetmeme.com/*",
+                "*://*.twitter.com/*"
             ]
         },
         {

--- a/plugins/twimg.js
+++ b/plugins/twimg.js
@@ -14,7 +14,7 @@ hoverZoomPlugins.push({
             /_bigger/,
             '_400x400'
         );
-        $('div.css-1dbjc4n.r-1twgtwe.r-sdzlij.r-rs99b7.r-1p0dtai.r-1mi75qu.r-1d2f490.r-u8s1d.r-zchlnj.r-ipm5af').css('pointer-events', 'none');
+        $('a[aria-haspopup="false"] > div:nth-child(2)').css('pointer-events', 'none');
         callback($(res));
     }
 });

--- a/plugins/twimg.js
+++ b/plugins/twimg.js
@@ -1,7 +1,7 @@
 ﻿var hoverZoomPlugins = hoverZoomPlugins || [];
 hoverZoomPlugins.push({
     name:'Twimg.com',
-    version:'0.1',
+    version:'0.2',
     prepareImgLinks:function (callback) {
         var res = [];
         hoverZoom.urlReplace(res,
@@ -9,6 +9,12 @@ hoverZoomPlugins.push({
             /_(normal|mini)/,
             ''
         );
+        hoverZoom.urlReplace(res,
+            'img[src*="twimg.com"]',
+            /_bigger/,
+            '_400x400'
+        );
+        $('div.css-1dbjc4n.r-1twgtwe.r-sdzlij.r-rs99b7.r-1p0dtai.r-1mi75qu.r-1d2f490.r-u8s1d.r-zchlnj.r-ipm5af').css('pointer-events', 'none');
         callback($(res));
     }
 });


### PR DESCRIPTION
- Added another urlReplace on twimg.js to account for the new mapping for the thumbnail and the full-size image.

- Also turned off the pointer-events for the new div that is covering the profile thumbs, and is preventing hoverzoom from accessing the <img> element.