### PR TITLE
Twitter: Fix loading profile images

### DIFF
--- a/plugins/twimg.js
+++ b/plugins/twimg.js
@@ -4,17 +4,16 @@ hoverZoomPlugins.push({
     version:'0.2',
     prepareImgLinks:function (callback) {
         var res = [];
+        // Same link without "_x96" loads the large version of the profile image.
         hoverZoom.urlReplace(res,
             'img[src*="twimg.com"]',
-            /_(normal|mini)/,
+            /_x96/,
             ''
         );
-        hoverZoom.urlReplace(res,
-            'img[src*="twimg.com"]',
-            /_bigger/,
-            '_400x400'
-        );
-        $('a[aria-haspopup="false"] > div:nth-child(2)').css('pointer-events', 'none');
+        // Links to profiles found on the main page or a Twitter list have "data-focusable=true".
+        $('a[data-focusable="true"] > div:nth-child(2)').css('pointer-events', 'none');
+        // Links to profiles found in the profile popup have "aria-hidden=true".
+        $('a[aria-hidden="true"] > div:nth-child(2)').css('pointer-events', 'none');
         callback($(res));
     }
 });


### PR DESCRIPTION
Profile images in quoted tweets are not inside `<a>` tags and still don't load. But the profile popup appears and the profile image in the popup does load if hovered.