### PR TITLE
Fix CORS downloads

### DIFF
--- a/js/hoverzoom.js
+++ b/js/hoverzoom.js
@@ -1462,7 +1462,7 @@ var hoverZoom = {
               headers: new Headers({
                 'Origin': location.origin
               }),
-              mode: 'cors'
+              mode: 'no-cors'
             })
             .then(response => response.blob())
             .then(blob => {


### PR DESCRIPTION
Changing the mode to `no-cors` seems to fix the saving issue on #633. 
I test it on pixiv.net and artstation.com and they both work fine.

might need more testing on another website.
Tested on Chromium 87