### PR TITLE
Fix for red spinner: now not displayed by default

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -367,6 +367,14 @@
         "message": "%",
         "description": "[options] Unit name (percentage) for opacity option"
     },
+    "optDisplayImageLoaderTooltip": {
+        "message": "Display a little spinner as image is loading (green:loading, orange:skipped, red:error). Orange & red spinners are optional.",
+        "description": "[options] Tooltip for display image loader option"
+    },
+    "optDisplayImageLoader": {
+        "message": "Display image loader",
+        "description": "[options] Display image loader option"
+    },    
     "optUseSeparateTabOrWindowForUnloadableUrlsTooltip": {
         "message": "Useful for HTTPS sites such as Google Images that prevent loading of HTTP images",
         "description": "[options] Tooltip for using separate tab or window for unloadable urls option"

--- a/html/options.html
+++ b/html/options.html
@@ -308,6 +308,14 @@
                                         <input class="xnarrow text input" type="text" id="txtPicturesOpacity"><span class="adjoined xnarrow" data-i18n="optOpacityUnitName"></span>
                                     </label>
                                 </li>
+                                <div class="ttip" data-i18n-tooltip="optDisplayImageLoaderTooltip">
+                                    <li class="field">
+                                        <label class="checkbox" for="chkDisplayImageLoader">
+                                            <input type="checkbox" id="chkDisplayImageLoader"><span></span>
+                                            <div style="display:inline" data-i18n="optDisplayImageLoader"></div>
+                                        </label>
+                                    </li>
+                                </div>
                                 <div class="ttip" data-i18n-tooltip="optDownloadFolderTooltip">
                                     <li class="append field">
                                         <label class="inline" style="padding-right:10px">

--- a/js/common.js
+++ b/js/common.js
@@ -28,7 +28,7 @@ var factorySettings = {
     disabledPlugins : [],
     centerImages : false,
     frameBackgroundColor: "#ffffff",
-    displayImageLoader: true,
+    displayImageLoader: false,
     enlargementThresholdEnabled : true,
     enlargementThreshold : 2,
     displayedSizeThresholdEnabled : true,

--- a/js/hoverzoom.js
+++ b/js/hoverzoom.js
@@ -265,7 +265,7 @@ var hoverZoom = {
 
                 imgFullSize.width('auto').height('auto');
                 hz.hzImg.width('auto').height('auto');
-                hz.hzImg.css('visibility', 'visible');
+                //hz.hzImg.css('visibility', 'visible');
 
                 // image natural dimensions
                 imgDetails.naturalWidth = imgFullSize.width() * options.zoomFactor;
@@ -727,12 +727,16 @@ var hoverZoom = {
         function displayFullSizeImage() {
             cLog('displayFullSizeImage');
 
-            hz.hzImgLoader.remove();
-            hz.hzImgLoader = null;
+            if (hz.hzImgLoader) {
+                hz.hzImgLoader.remove();
+                hz.hzImgLoader = null;
+            }
 
             hz.hzImg.stop(true, true);
             hz.hzImg.offset({top:-9000, left:-9000});    // hides the image while making it available for size calculations
             hz.hzImg.empty();
+
+            hz.hzImg.css('visibility', 'visible');
 
             clearTimeout(cursorHideTimeout);
             hz.hzImg.css('cursor', 'none');
@@ -1656,9 +1660,15 @@ var hoverZoom = {
         }
     },
 
-    // create and display the loading image container
-
+    // handle the loading image spinner
+    // its color depends on loading staus:
+    // - green: loading started
+    // - orange: img skipped (reason depends on Options settings: image already big enough, etc)
+    // - red: an error occured (displayed in console)
     displayImgLoader:function (status, position) {
+
+        // orange & red spinners are optional
+        if (options.displayImageLoader == false && (status == 'skipped' || status == 'error')) return;
 
         // check that loader exists
         if (hoverZoom.hzImgLoader == null) {

--- a/js/options.js
+++ b/js/options.js
@@ -114,6 +114,7 @@ function saveOptions() {
     options.enableGalleries = $('#chkEnableGalleries')[0].checked;
     options.picturesOpacity = $('#txtPicturesOpacity')[0].value / 100;
     options.captionLocation = $('#selectCaptionLocation').val();
+    options.displayImageLoader = $('#chkDisplayImageLoader')[0].checked;    
     options.downloadFolder = $('#txtDownloadFolder')[0].value;
     options.useSeparateTabOrWindowForUnloadableUrlsEnabled = $('#chkUseSeparateTabOrWindowForUnloadableUrlsEnabled')[0].checked;
     options.useSeparateTabOrWindowForUnloadableUrls = $('#selectUseSeparateTabOrWindowForUnloadableUrls').val();


### PR DESCRIPTION
@extesy, i first decided to remove all spinners (green, orange, red) but i changed my mind and kept the green one. 
I spared it because it's the only visual clue for users that HZ+ is actually doing something (=trying to zoom the image under mouse pointer!).
Another option whould be to modify the look of image being hovered, like Imagus that adds a dotted border around image.
I did some tests, it is not fully reliable, so maybe we should keep the green spinner for now, what do you think?
By default, red and future orange spinners are disabled.