### PR TITLE
Speed-up images display in 500px & Facebook plug-ins

### DIFF
--- a/plugins/500px.js
+++ b/plugins/500px.js
@@ -78,6 +78,7 @@ hoverZoomPlugins.push({
                                 link.data().hoverZoomSrc.unshift(fullsizeUrl);
                                 link.addClass('hoverZoomLink');
                                 callback(link);
+                                hoverZoom.displayPicFromElement(link);
                             }
                         }
                     });
@@ -97,6 +98,7 @@ hoverZoomPlugins.push({
                             link.data().hoverZoomSrc.unshift(fullsizeUrl);
                             link.addClass('hoverZoomLink');
                             callback(link);
+                            hoverZoom.displayPicFromElement(link);
                         }
                     }
                 }
@@ -163,6 +165,7 @@ hoverZoomPlugins.push({
                                 link.data().hoverZoomSrc.unshift(fullsizeUrl);
                                 link.addClass('hoverZoomLink');
                                 callback(link);
+                                hoverZoom.displayPicFromElement(link);
                             }
                         }
                     });
@@ -182,6 +185,7 @@ hoverZoomPlugins.push({
                             link.data().hoverZoomSrc.unshift(fullsizeUrl);
                             link.addClass('hoverZoomLink');
                             callback(link);
+                            hoverZoom.displayPicFromElement(link);
                         }
                     }
                 }

--- a/plugins/facebook.js
+++ b/plugins/facebook.js
@@ -149,6 +149,7 @@ hoverZoomPlugins.push({
                 // store uri
                 sessionStorage.setItem(currentId, uri);
                 callback(currentLink, name);
+                hoverZoom.displayPicFromElement(currentLink);
             });
         }
 
@@ -266,6 +267,7 @@ hoverZoomPlugins.push({
                     res.push(link);
                     cLog('Facebook photo fullsizeUrl (from sessionStorage): ' + storedUrl);
                     callback(link, name);
+                    hoverZoom.displayPicFromElement(link);
                 }
             }
         }
@@ -296,6 +298,7 @@ hoverZoomPlugins.push({
             // store uri
             sessionStorage.setItem(id, uri);
             callback(link, name);
+            hoverZoom.displayPicFromElement(link);
             return true;
         }
 
@@ -333,6 +336,7 @@ hoverZoomPlugins.push({
                     data.hoverZoomSrc.unshift(storedUrl);
                     cLog('Facebook photo fullsizeUrl (from sessionStorage): ' + storedUrl);
                     callback(currentLink, name);
+                    hoverZoom.displayPicFromElement(currentLink);
                 }
             });
         };
@@ -404,6 +408,7 @@ hoverZoomPlugins.push({
                 res.push(link);
                 cLog('Facebook photo fullsizeUrl (from sessionStorage): ' + storedUrl);
                 callback(link, name);
+                hoverZoom.displayPicFromElement(link);
             }
         }
 
@@ -507,6 +512,7 @@ hoverZoomPlugins.push({
                 res.push(link);
                 cLog('Facebook photo fullsizeUrl (from sessionStorage): ' + storedUrl);
                 callback(link, name);
+                hoverZoom.displayPicFromElement(link);
             }
         });
 


### PR DESCRIPTION
Added a call to : hoverZoom.displayPicFromElement(link) to force immediate display of zoomed pictures