### PR TITLE
Little improvements

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -374,7 +374,7 @@
     "optDisplayImageLoader": {
         "message": "Display a red spinner when image loading failed",
         "description": "[options] Display image loader option"
-    },    
+    },
     "optUseSeparateTabOrWindowForUnloadableUrlsTooltip": {
         "message": "Useful for HTTPS sites such as Google Images that prevent loading of HTTP images",
         "description": "[options] Tooltip for using separate tab or window for unloadable urls option"
@@ -480,7 +480,7 @@
         "description": "[options] Report a bug link in page footer"
     },
     "optFooterVersionCopyright": {
-        "message": "Version $1 - © 2014-2020 Oleg Anashkin",
+        "message": "Version $1 - © 2014-2021 Oleg Anashkin",
         "description": "[options] Copyright and version number in page footer"
     }
 }

--- a/js/common.js
+++ b/js/common.js
@@ -46,7 +46,8 @@ var factorySettings = {
     openImageInTabKey : 84,
     saveImageKey : 83,
     prevImgKey : 37,
-    nextImgKey : 39
+    nextImgKey : 39,
+    escKey : 27
 }
 
 // Load options from factory settings (= as if extension has just been installed from webstore)
@@ -116,6 +117,7 @@ function loadOptions() {
     options.saveImageKey = options.hasOwnProperty('saveImageKey') ? options.saveImageKey : factorySettings.saveImageKey;
     options.prevImgKey = options.hasOwnProperty('prevImgKey') ? options.prevImgKey : factorySettings.prevImgKey;
     options.nextImgKey = options.hasOwnProperty('nextImgKey') ? options.nextImgKey : factorySettings.nextImgKey;
+    options.escKey = factorySettings.escKey;
 
     localStorage.options = JSON.stringify(options);
 


### PR DESCRIPTION
- "**panic mode**": **ESC key now closes zoomed images** (some users are probably not aware of the Hide action-key, whereas Escape key usage is well-known)
- fix #638 : "Audio for Hoverzoome'd video will play in background even after video closes"
- fix rare bug with background images
- update version & copyright footer