### PR TITLE
Fix for embedded images

### DIFF
--- a/js/hoverzoom.js
+++ b/js/hoverzoom.js
@@ -1647,11 +1647,22 @@ var hoverZoom = {
     getThumbUrl:function (el) {
         var compStyle = (el && el.nodeType == 1) ? getComputedStyle(el) : false,
             backgroundImage = compStyle ? compStyle.backgroundImage : 'none';
-        if (backgroundImage.indexOf("url") != -1 && backgroundImage.indexOf('data:image') == -1 && backgroundImage.indexOf('base64') == -1) {
+
+        if (backgroundImage.indexOf("url") != -1) {
+            if (hoverZoom.isEmbeddedImg(backgroundImage)) return ''; // discard embedded images
             return backgroundImage.replace(/.*url\s*\(\s*(.*)\s*\).*/i, '$1').replace(/"/g,'');
-        } else {
-            return el.src || el.href;
         }
+
+        if (hoverZoom.isEmbeddedImg(el.src)) return ''; // discard embedded images
+        return el.src || el.href;
+    },
+
+    // Embedded image url look like:  "data:image/png;base64,Base64 encoded string of the image"
+    // sample: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg=="
+    isEmbeddedImg:function (url) {
+        if (!url) return false;
+        if (url.indexOf('data:image') === -1 && url.indexOf('base64') === -1) return false;
+        return true;
     },
 
     // Simulates a mousemove event to force a zoom call


### PR DESCRIPTION
Running a regEx on embedded images'urls like this one: 

_data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==_

is :
- **useless** since they will not be zommed,
- **problematic** when base64 encoded string of the image is thousands of characters long : in such case regEx can cost **dozen of seconds to evaluate**, causing browser freeze (#715).

So they must be filtered out (this applies to regular & background images)