### PR TITLE
New option: rename when saving images & videos

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -400,8 +400,40 @@
         "description": "[options] Placeholder for download folder option"
     },
     "optDownloadFolder": {
-        "message": "Save images to folder: Downloads/",
+        "message": "Save images & videos to folder: Downloads/",
         "description": "[options] Download folder option"
+    },
+    "optRenameDownloadsTooltip": {
+        "message": "Prefix original names of downloads with origin, size and/or duration for easier management",
+        "description": "[options] Tooltip for rename downloads option"
+    },
+    "optRenameDownloads": {
+        "message": "Rename saved images & videos by adding:",
+        "description": "[options] Rename downloads option"
+    },
+    "optAddDownloadOriginTooltip": {
+        "message": "Add origin (e.g. www.deviantart.com)",
+        "description": "[options] Tooltip for add download origin option"
+    },
+    "optAddDownloadOrigin": {
+        "message": "origin",
+        "description": "[options] Add download origin option"
+    },
+    "optAddDownloadSizeTooltip": {
+        "message": "Add size (WxH) in pixels (e.g. 1024x750)",
+        "description": "[options] Tooltip for add download size option"
+    },
+    "optAddDownloadSize": {
+        "message": "size",
+        "description": "[options] Add download size option"
+    },
+    "optAddDownloadDurationTooltip": {
+        "message": "Add duration (hh mm ss) of video (e.g. 00 16 35)",
+        "description": "[options] Tooltip for add download duration option"
+    },
+    "optAddDownloadDuration": {
+        "message": "duration",
+        "description": "[options] Add download duration option"
     },
     "optPixelsUnitName": {
         "message": "pixels",

--- a/html/options.html
+++ b/html/options.html
@@ -324,6 +324,37 @@
                                         <input class="normal text input" type="text" id="txtDownloadFolder" data-i18n-placeholder="optDownloadFolderPlaceholder">
                                     </li>
                                 </div>
+                                <div style="display:flex">
+                                    <div class="ttip" data-i18n-tooltip="optRenameDownloadsTooltip">
+                                        <label class="inline" for="txtRenameDownloads">
+                                            <div style="display:inline" data-i18n="optRenameDownloads"></div>
+                                        </label>
+                                    </div>
+                                    <div class="ttip" data-i18n-tooltip="optAddDownloadOriginTooltip">
+                                        <div class="field">
+                                            <label class="checkbox" style="padding-right:100px" for="chkAddDownloadOrigin">
+                                                <input type="checkbox" id="chkAddDownloadOrigin"><span></span>
+                                                <div style="display:inline" data-i18n="optAddDownloadOrigin"></div>
+                                            </label>
+                                        </div>
+                                    </div>
+                                   <div class="ttip" data-i18n-tooltip="optAddDownloadSizeTooltip">
+                                        <div class="field">
+                                            <label class="checkbox" style="padding-right:100px" for="chkAddDownloadSize">
+                                                <input type="checkbox" id="chkAddDownloadSize"><span></span>
+                                                <div style="display:inline" data-i18n="optAddDownloadSize"></div>
+                                            </label>
+                                        </div>
+                                    </div>
+                                    <div class="ttip" data-i18n-tooltip="optAddDownloadDurationTooltip">
+                                        <div class="field">
+                                            <label class="checkbox" for="chkAddDownloadDuration">
+                                                <input type="checkbox" id="chkAddDownloadDuration"><span></span>
+                                                <div style="display:inline" data-i18n="optAddDownloadDuration"></div>
+                                            </label>
+                                        </div>
+                                    </div>
+                                </div>
                             </ul>
                         </fieldset>
                     </form>

--- a/js/common.js
+++ b/js/common.js
@@ -36,6 +36,9 @@ var factorySettings = {
     zoomedSizeThresholdEnabled : true,
     zoomedSizeThreshold : 100,
     downloadFolder : '',
+    addDownloadOrigin : false,
+    addDownloadSize : false,
+    addDownloadDuration : false,
     useSeparateTabOrWindowForUnloadableUrlsEnabled: false,
     useSeparateTabOrWindowForUnloadableUrls: 'window',
     captionLocation : 'below',
@@ -101,6 +104,9 @@ function loadOptions() {
     options.zoomedSizeThresholdEnabled = options.hasOwnProperty('zoomedSizeThresholdEnabled') ? options.zoomedSizeThresholdEnabled : factorySettings.zoomedSizeThresholdEnabled;
     options.zoomedSizeThreshold = options.hasOwnProperty('zoomedSizeThreshold') ? options.zoomedSizeThreshold : factorySettings.zoomedSizeThreshold;
     options.downloadFolder = options.hasOwnProperty('downloadFolder') ? options.downloadFolder : factorySettings.downloadFolder;
+    options.addDownloadOrigin = options.hasOwnProperty('addDownloadOrigin') ? options.addDownloadOrigin : factorySettings.addDownloadOrigin;
+    options.addDownloadSize = options.hasOwnProperty('addDownloadSize') ? options.addDownloadSize : factorySettings.addDownloadSize;
+    options.addDownloadDuration = options.hasOwnProperty('addDownloadDuration') ? options.addDownloadDuration : factorySettings.addDownloadDuration;
     options.useSeparateTabOrWindowForUnloadableUrlsEnabled = options.hasOwnProperty('useSeparateTabOrWindowForUnloadableUrlsEnabled') ? options.useSeparateTabOrWindowForUnloadableUrlsEnabled : factorySettings.useSeparateTabOrWindowForUnloadableUrlsEnabled;
     options.useSeparateTabOrWindowForUnloadableUrls = options.hasOwnProperty('useSeparateTabOrWindowForUnloadableUrls') ? options.useSeparateTabOrWindowForUnloadableUrls : factorySettings.useSeparateTabOrWindowForUnloadableUrls;
 

--- a/js/options.js
+++ b/js/options.js
@@ -116,6 +116,9 @@ function saveOptions() {
     options.captionLocation = $('#selectCaptionLocation').val();
     options.displayImageLoader = $('#chkDisplayImageLoader')[0].checked;    
     options.downloadFolder = $('#txtDownloadFolder')[0].value;
+    options.addDownloadOrigin = $('#chkAddDownloadOrigin')[0].checked;
+    options.addDownloadSize = $('#chkAddDownloadSize')[0].checked;
+    options.addDownloadDuration = $('#chkAddDownloadDuration')[0].checked;
     options.useSeparateTabOrWindowForUnloadableUrlsEnabled = $('#chkUseSeparateTabOrWindowForUnloadableUrlsEnabled')[0].checked;
     options.useSeparateTabOrWindowForUnloadableUrls = $('#selectUseSeparateTabOrWindowForUnloadableUrls').val();
 
@@ -203,6 +206,9 @@ function restoreOptions(optionsFromFactorySettings) {
     $('#chkZoomedSizeThresholdEnabled').trigger(options.zoomedSizeThresholdEnabled ? 'gumby.check' : 'gumby.uncheck');
     $('#txtZoomedSizeThreshold').val(parseInt(options.zoomedSizeThreshold));
     $('#txtDownloadFolder').val(options.downloadFolder);
+    $('#chkAddDownloadOrigin').trigger(options.addDownloadOrigin ? 'gumby.check' : 'gumby.uncheck');
+    $('#chkAddDownloadSize').trigger(options.addDownloadSize ? 'gumby.check' : 'gumby.uncheck');
+    $('#chkAddDownloadDuration').trigger(options.addDownloadDuration ? 'gumby.check' : 'gumby.uncheck');
     $('#chkUseSeparateTabOrWindowForUnloadableUrlsEnabled').trigger(options.useSeparateTabOrWindowForUnloadableUrlsEnabled ? 'gumby.check' : 'gumby.uncheck');
     $('#selectUseSeparateTabOrWindowForUnloadableUrls').val(options.useSeparateTabOrWindowForUnloadableUrls);
 
@@ -319,6 +325,7 @@ function updateUseSeparateTabOrWindowForUnloadableUrls() {
         $('#selectUseSeparateTabOrWindowForUnloadableUrls').addClass('disabled');
     }
 }
+
 function updateTxtAmbilightBackgroundOpacity() {
     $('#txtAmbilightBackgroundOpacity')[0].value = this.value;
 }


### PR DESCRIPTION
In order to ease management, filenames of saved images & videos can be prefixed with:

- **origin**
- **size**
- **duration** (videos only)

For instance, a 1200x900 picture saved fron DeviantArt with original filename: WhiteRabbit.jpg
will be renamed to: [www.deviantart.com][1200x900]WhiteRabbit.jpg

This option is **disabled** by default.