### PR TITLE
New action key for Copy Image URL : U

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -49,7 +49,7 @@ var factorySettings = {
     actionKey : 0,
     fullZoomKey : 90,
     copyImageKey: 67,
-    copyImageUrlKey: 76,
+    copyImageUrlKey: 85,
     hideKey : 88,
     openImageInWindowKey : 87,
     openImageInTabKey : 84,


### PR DESCRIPTION
Follow-up to #768 by @George-lewis so action key L is for image locking by default.