### PR TITLE
New Advanced option: enable debug

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -495,6 +495,18 @@
         "message": "duration",
         "description": "[options] Add download duration option"
     },
+    "optSectionTroubleshooting": {
+        "message": "Troubleshooting",
+        "description": "[options] Page section for troubleshooting"
+    },
+    "optEnableDebugTooltip": {
+        "message": "Display debug messages in browser's console (to open console: press F12)",
+        "description": "[options] Tooltip for enable debug option"
+    },
+    "optEnableDebug": {
+        "message": "Enable debug",
+        "description": "[options] Enable debug option"
+    },
     "optPixelsUnitName": {
         "message": "pixels",
         "description": "[options] Unit name (pixels)"

--- a/html/options.html
+++ b/html/options.html
@@ -404,6 +404,19 @@
                                 </div>
                             </ul>
                         </fieldset>
+                        <fieldset>
+                            <legend data-i18n="optSectionTroubleshooting"></legend>
+                            <ul>
+                                <div class="ttip" data-i18n-tooltip="optEnableDebugTooltip">
+                                    <li class="field">
+                                        <label class="checkbox" for="chkEnableDebug">
+                                            <input type="checkbox" id="chkEnableDebug"><span></span>
+                                            <div style="display:inline" data-i18n="optEnableDebug"></div>
+                                        </label>
+                                    </li>
+                                </div>
+                            </ul>
+                        </fieldset>
                     </form>
                 </div>
             </section>

--- a/js/common.js
+++ b/js/common.js
@@ -60,7 +60,8 @@ var factorySettings = {
     prevImgKey : 37,
     nextImgKey : 39,
     flipImageKey : 70,
-    escKey : 27
+    escKey : 27,
+    debug : false
 }
 
 // Load options from factory settings (= as if extension has just been installed from webstore)
@@ -145,6 +146,9 @@ function loadOptions() {
     options.nextImgKey = options.hasOwnProperty('nextImgKey') ? options.nextImgKey : factorySettings.nextImgKey;
     options.flipImageKey = options.hasOwnProperty('flipImageKey') ? options.flipImageKey : factorySettings.flipImageKey;
     options.escKey = factorySettings.escKey;
+
+    // debug
+    options.debug = options.hasOwnProperty('debug') ? options.debug : factorySettings.debug;
 
     localStorage.options = JSON.stringify(options);
 

--- a/js/hoverzoom.js
+++ b/js/hoverzoom.js
@@ -2169,13 +2169,15 @@ var hoverZoom = {
         }
 
         function downloadResource(url, filename, callback) {
+            cLog('download: ' + url);
             if (!filename) filename = url.split('\\').pop().split('/').pop();
 
             // prefix with download folder if needed
             if (options.downloadFolder) {
-
+                cLog('options.downloadFolder: ' + options.downloadFolder);
                 let downloadFolder = options.downloadFolder;
                 filename = downloadFolder + filename;
+                cLog('filename: ' + filename);
             }
 
             chrome.runtime.sendMessage({
@@ -2485,6 +2487,9 @@ var hoverZoom = {
             prepareImgLinks();
             bindEvents();
             fixFlash();
+
+            debug = options.debug;
+
         }
 
         chrome.runtime.onMessage.addListener(onMessage);

--- a/js/options.js
+++ b/js/options.js
@@ -131,6 +131,7 @@ function saveOptions() {
     options.downloadFolder = $('#txtDownloadFolder')[0].value;
     options.addDownloadOrigin = $('#chkAddDownloadOrigin')[0].checked;
     options.addDownloadSize = $('#chkAddDownloadSize')[0].checked;
+    options.debug = $('#chkEnableDebug')[0].checked;
     options.addDownloadDuration = $('#chkAddDownloadDuration')[0].checked;
     options.useSeparateTabOrWindowForUnloadableUrlsEnabled = $('#chkUseSeparateTabOrWindowForUnloadableUrlsEnabled')[0].checked;
     options.useSeparateTabOrWindowForUnloadableUrls = $('#selectUseSeparateTabOrWindowForUnloadableUrls').val();
@@ -232,6 +233,7 @@ function restoreOptions(optionsFromFactorySettings) {
     $('#chkAddDownloadDuration').trigger(options.addDownloadDuration ? 'gumby.check' : 'gumby.uncheck');
     $('#chkUseSeparateTabOrWindowForUnloadableUrlsEnabled').trigger(options.useSeparateTabOrWindowForUnloadableUrlsEnabled ? 'gumby.check' : 'gumby.uncheck');
     $('#selectUseSeparateTabOrWindowForUnloadableUrls').val(options.useSeparateTabOrWindowForUnloadableUrls);
+    $('#chkEnableDebug').trigger(options.debug ? 'gumby.check' : 'gumby.uncheck');
 
     return false;
 }


### PR DESCRIPTION
Rework of #740 by @Mattwmaster58 : a new section "Troubleshooting" is added to Advanced Options page.

![image](https://user-images.githubusercontent.com/23529041/132850682-1acd3b53-5b81-4804-85a6-fc9f1639f2ac.png)

By default, debug is **disabled**.