### PR TITLE
Enhancement: display an error msg when a video does not start

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -618,5 +618,9 @@
     "optFooterVersionCopyright": {
         "message": "Version $1 - © 2014-2021 Oleg Anashkin",
         "description": "[options] Copyright and version number in page footer"
+    },
+    "msgClickPageToPlayVideo": {
+        "message": "click page then hover again",
+        "description": "User must interact with the document first to play video: https://goo.gl/xX8pDD"
     }
 }


### PR DESCRIPTION
To start video playback, user must first interact with the page or there is an error message:
NotAllowedError: play() failed because the user didn't interact with the document first. https://goo.gl/xX8pDD

A (blinking) text message reminds user to do so:

![click_page_then_over_again](https://user-images.githubusercontent.com/23529041/146688707-aa0e32ed-f651-4d4b-99a1-521b737ed70e.png)

