### PR TITLE
Improvements on Options page

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -611,12 +611,16 @@
         "message": "Source code",
         "description": "[options] Source code link in page footer"
     },
+    "optFooterChangelog": {
+        "message": "Changelog",
+        "description": "[options] Changelog link in page footer"
+    },
     "optFooterReportIssue": {
         "message": "Report a bug",
         "description": "[options] Report a bug link in page footer"
     },
     "optFooterVersionCopyright": {
-        "message": "Version $1 - © 2014-2021 Oleg Anashkin",
+        "message": "Version $1 (last update: $2) - © 2014-2022 Oleg Anashkin",
         "description": "[options] Copyright and version number in page footer"
     },
     "msgClickPageToPlayVideo": {

--- a/html/options.html
+++ b/html/options.html
@@ -439,7 +439,7 @@
         </div>
         <div class="row">
             <div class="twelve columns centered text-center">
-                <p><a target="_blank" href="https://github.com/extesy/hoverzoom/" data-i18n="optFooterSourceCode"></a> | <a target="_blank" href="https://github.com/extesy/hoverzoom/issues" data-i18n="optFooterReportIssue"></a></p>
+                <p><a target="_blank" href="https://github.com/extesy/hoverzoom/" data-i18n="optFooterSourceCode"></a> | <a target="_blank" href="https://github.com/extesy/hoverzoom/blob/master/CHANGELOG.md" data-i18n="optFooterChangelog"></a> | <a target="_blank" href="https://github.com/extesy/hoverzoom/issues" data-i18n="optFooterReportIssue"></a></p>
                 <p id="version"></p>
             </div>
         </div>

--- a/js/background.js
+++ b/js/background.js
@@ -142,4 +142,26 @@ function init() {
     chrome.runtime.onMessage.addListener(onMessage);
 }
 
+// Store HZ+ dates of installation & last update
+chrome.runtime.onInstalled.addListener((details) => {
+
+    const reason = details.reason;
+    let d = new Date();
+    let options = { weekday: 'short', year: 'numeric', month: 'short', day: 'numeric' };
+
+    switch (reason) {
+        case 'install':
+            localStorage['HoverZoomInstallation'] = d.toLocaleDateString(undefined, options);
+            break;
+        case 'update':
+            localStorage['HoverZoomLastUpdate'] = d.toLocaleDateString(undefined, options);
+            break;
+        case 'chrome_update':
+        case 'shared_module_update':
+        default:
+            // Other install events within the browser
+            break;
+    }
+})
+
 init();

--- a/js/options.js
+++ b/js/options.js
@@ -1,7 +1,7 @@
 var options,
     hoverZoomPlugins = hoverZoomPlugins || [],
     VK_CTRL = 1024,
-    VK_SHIFT = 2048,    
+    VK_SHIFT = 2048,
     actionKeys = ['actionKey', 'hideKey', 'openImageInWindowKey', 'openImageInTabKey', 'lockImageKey', 'saveImageKey', 'fullZoomKey', 'prevImgKey', 'nextImgKey', 'flipImageKey', 'copyImageKey', 'copyImageUrlKey'];
 
 function getMilliseconds(ctrl) {
@@ -470,7 +470,7 @@ $(function () {
     i18n();
     chkWhiteListModeOnChange();
     initAddToHistory();
-    $("#version").text(chrome.i18n.getMessage("optFooterVersionCopyright", chrome.runtime.getManifest().version));
+    $("#version").text(chrome.i18n.getMessage("optFooterVersionCopyright", [chrome.runtime.getManifest().version, localStorage['HoverZoomLastUpdate'] ? localStorage['HoverZoomLastUpdate'] : localStorage['HoverZoomInstallation']]));
     $('#btnSave').click(saveOptions);
     $('#btnCancel').click(function() { restoreOptions() });
     $('#btnReset').click(restoreOptionsFromFactorySettings);


### PR DESCRIPTION
- Link to **Changelog** in footer.
- Display **date of installation or last update** in footer on Options pages. This additional info will help users detect & (hopefully) report regressions.

![footer](https://user-images.githubusercontent.com/23529041/147854471-fb3153f9-7515-4ce0-bb56-1f384b9b7092.JPG)

