### PR TITLE
Rework of Action keys

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -507,12 +507,28 @@
         "message": "If a key is set, Hover Zoom+ will be active only when this key is held down.",
         "description": "[options] Action key description"
     },
+    "optToggleKeyTitle": {
+    	"message": "Toggle HoverZoom+",
+    	"description": "[options] Action key title"
+    },
+    "optToggleKeyDescription": {
+    	"message": "Enable/disable HoverZoom+",
+    	"description": "[options] Action key description"
+    },
+    "optCloseKeyTitle": {
+    	"message": "Close image",
+    	"description": "[options] Action key title"
+    },
+    "optCloseKeyDescription": {
+    	"message": "Press this key to close zoomed image or video.",
+    	"description": "[options] Action key description"
+    },
     "optHideKeyTitle": {
-        "message": "Disable Hover Zoom+",
+        "message": "Hide image",
         "description": "[options] Action key title"
     },
     "optHideKeyDescription": {
-        "message": "Holding this key down hides the zoomed picture. Use it when the picture hides elements that are also displayed on mouseover.",
+        "message": "Holding this key down hides the zoomed image or video. Use it when the picture hides elements that are also displayed on mouseover.",
         "description": "[options] Action key description"
     },
     "optOpenImageInWindowKeyTitle": {
@@ -520,7 +536,7 @@
         "description": "[options] Action key title"
     },
     "optOpenImageInWindowKeyDescription": {
-        "message": "Press this key to open the image you are currently viewing in a new window. Press this key again to close the window.",
+        "message": "Press this key to open the image or video you are currently viewing in a new window. Press this key again to close the window.",
         "description": "[options] Action key description"
     },
     "optOpenImageInTabKeyTitle": {
@@ -528,7 +544,7 @@
         "description": "[options] Action key title"
     },
     "optOpenImageInTabKeyDescription": {
-        "message": "Press this key to open the image you are currently viewing in a new tab. Press this key again to close the tab. Shift+key opens the image in a background tab.",
+        "message": "Press this key to open the image or video you are currently viewing in a new tab. Press this key again to close the tab. Shift+key opens the image in a background tab.",
         "description": "[options] Action key description"
     },
     "optLockImageKeyTitle": {
@@ -536,7 +552,7 @@
         "description": "[options] Action key title"
     },
     "optLockImageKeyDescription": {
-        "message": "Press this key to lock the image in the center of the page, allowing you to zoom and pan around. Press ESC or click outside the image to unlock the image.",
+        "message": "Press this key to lock the image or video in the center of the page, allowing you to zoom and pan around. Press close key or click outside the image to unlock.",
         "description": "[options] Action key description"
     },
     "optSaveImageKeyTitle": {
@@ -544,7 +560,7 @@
         "description": "[options] Action key title"
     },
     "optSaveImageKeyDescription": {
-        "message": "Press this key to save the image you are currently viewing.",
+        "message": "Press this key to save the image or video you are currently viewing.",
         "description": "[options] Action key description"
     },
     "optFullZoomKeyTitle": {

--- a/js/common.js
+++ b/js/common.js
@@ -49,6 +49,7 @@ var factorySettings = {
     fontSize : 11,
     fontOutline : false,
     actionKey : 0,
+    toggleKey : 69,
     fullZoomKey : 90,
     copyImageKey: 67,
     copyImageUrlKey: 85,
@@ -60,7 +61,7 @@ var factorySettings = {
     prevImgKey : 37,
     nextImgKey : 39,
     flipImageKey : 70,
-    escKey : 27,
+    closeKey : 27,
     debug : false
 }
 
@@ -134,6 +135,7 @@ function loadOptions() {
 
     // Action keys
     options.actionKey = options.hasOwnProperty('actionKey') ? options.actionKey : factorySettings.actionKey;
+    options.toggleKey = options.hasOwnProperty('toggleKey') ? options.toggleKey : factorySettings.toggleKey;
     options.fullZoomKey = options.hasOwnProperty('fullZoomKey') ? options.fullZoomKey : factorySettings.fullZoomKey;
     options.copyImageKey = options.hasOwnProperty('copyImageKey') ? options.copyImageKey : factorySettings.copyImageKey;
     options.copyImageUrlKey = options.hasOwnProperty('copyImageUrlKey') ? options.copyImageUrlKey : factorySettings.copyImageUrlKey;
@@ -145,7 +147,7 @@ function loadOptions() {
     options.prevImgKey = options.hasOwnProperty('prevImgKey') ? options.prevImgKey : factorySettings.prevImgKey;
     options.nextImgKey = options.hasOwnProperty('nextImgKey') ? options.nextImgKey : factorySettings.nextImgKey;
     options.flipImageKey = options.hasOwnProperty('flipImageKey') ? options.flipImageKey : factorySettings.flipImageKey;
-    options.escKey = factorySettings.escKey;
+    options.closeKey = options.hasOwnProperty('closeKey') ? options.closeKey : factorySettings.closeKey;
 
     // debug
     options.debug = options.hasOwnProperty('debug') ? options.debug : factorySettings.debug;

--- a/js/hoverzoom.js
+++ b/js/hoverzoom.js
@@ -1970,6 +1970,21 @@ var hoverZoom = {
             if (event.target && ['INPUT','TEXTAREA','SELECT'].indexOf(event.target.tagName) > -1) {
                 return;
             }
+            // Toggle key is pressed down
+            if (event.which == options.toggleKey) {
+                options.extensionEnabled = !options.extensionEnabled;
+                if (! options.extensionEnabled) { 
+                    // close zoomed image or video
+                    imageLocked = false;
+                    if (hz.hzImg) {
+                        stopMedias();
+                        hz.hzImg.hide();
+                    }
+                    if (imgFullSize) {
+                        return false;
+                    }
+                }
+            }
             // Action key (zoom image) is pressed down
             if (event.which == options.actionKey && !actionKeyDown) {
                 actionKeyDown = true;
@@ -1986,8 +2001,9 @@ var hoverZoom = {
                     return false;
                 }
             }
-            // escape key is pressed down
-            if (event.which == options.escKey) {
+            // close key (close zoomed image) is pressed down
+            // => zoomed image is closed immediately
+            if (event.which == options.closeKey) {
                 imageLocked = false;
                 if (hz.hzImg) {
                     stopMedias();
@@ -1998,6 +2014,7 @@ var hoverZoom = {
                 }
             }
             // hide key (hide zoomed image) is pressed down
+            // => zoomed image remains hidden until key is released
             if (event.which == options.hideKey && !hideKeyDown) {
                 hideKeyDown = true;
                 if (hz.hzImg) {

--- a/js/options.js
+++ b/js/options.js
@@ -2,7 +2,7 @@ var options,
     hoverZoomPlugins = hoverZoomPlugins || [],
     VK_CTRL = 1024,
     VK_SHIFT = 2048,
-    actionKeys = ['actionKey', 'hideKey', 'openImageInWindowKey', 'openImageInTabKey', 'lockImageKey', 'saveImageKey', 'fullZoomKey', 'prevImgKey', 'nextImgKey', 'flipImageKey', 'copyImageKey', 'copyImageUrlKey'];
+    actionKeys = ['actionKey', 'toggleKey', 'closeKey', 'hideKey', 'openImageInWindowKey', 'openImageInTabKey', 'lockImageKey', 'saveImageKey', 'fullZoomKey', 'prevImgKey', 'nextImgKey', 'flipImageKey', 'copyImageKey', 'copyImageUrlKey'];
 
 function getMilliseconds(ctrl) {
     var value = parseFloat(ctrl.val());
@@ -61,6 +61,7 @@ function loadKeys(sel) {
     for (var i = 112; i < 124; i++) {
         $('<option value="' + i + '">F' + (i - 111) + '</option>').appendTo(sel);
     }
+    $('<option value="27">Escape</option>').appendTo(sel);
     $('<option value="33">Page Up</option>').appendTo(sel);
     $('<option value="34">Page Down</option>').appendTo(sel);
     $('<option value="35">End</option>').appendTo(sel);


### PR DESCRIPTION
2 keys added:
 - "Toggle HZ+": quick way to enable/disble HZ+ without using Options page (default key: E)
 - "Close image": close image (or video) being zoomed, instead of just hiding it temporarily (default key: ESC)

Some rewording to make these settings less confusing (i hope)

![action_keys](https://user-images.githubusercontent.com/23529041/154679987-3a812eb8-915b-4e8f-ada4-b3a29737dd31.JPG)

