### PR TITLE
Fix for: #881

### DIFF
--- a/js/hoverzoom.js
+++ b/js/hoverzoom.js
@@ -1346,6 +1346,9 @@ var hoverZoom = {
 
             if (options.addToHistory && !chrome.extension.inIncognitoContext) {
                 chrome.runtime.sendMessage({action:'addUrlToHistory', url:imgDetails.url});
+                // #881: add link url to history if available, this is needed to turn hovered links purple
+                let linkUrl = hz.currentLink.prop('href');
+                if (linkUrl != imgDetails.url) chrome.runtime.sendMessage({action:'addUrlToHistory', url:linkUrl});
             }
         }
 


### PR DESCRIPTION
@extesy @mobad @JunoArc 
Actually there are 2 distinct issues:
- **adding urls of zoomed images & videos to browser's history**: this works fine (on all sites, not only Reddit), it was the purpose of #873 
- **turning links color to purple once hovered**: this does not work if image's url differs from link's href, as in Reddit. So i also added href to history (as suggested by @mobad)