### PR TITLE
New popup for action keys

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -59,6 +59,14 @@
         "message": "Options saved. Some settings might need a page refresh.",
         "description": "[options] Notification after saving options"
     },
+    "optCancel": {
+  	"message": "Modification(s) cancelled.",
+        "description": "[options] Notification after cancelling modification(s) to options"
+    },
+    "optReset": {
+        "message": "Options reset to factory settings, save to apply.",
+        "description": "[options] Notification after resetting options to factory settings"
+    },
     "optPageGeneral": {
         "message": "General",
         "description": "[options] Page title for general options"

--- a/css/style.css
+++ b/css/style.css
@@ -1,7 +1,8 @@
 #messages {
-    opacity: 0;
     margin-top: 2em;
     margin-bottom: 2em;
+    display: flex;
+    justify-content: center;
 }
 
 .append input[type=range] + input[type=text] {
@@ -60,3 +61,28 @@ select.picker {
 legend {
     font-weight: bold;
 }
+
+.popup table { width: max-content; margin-bottom: 0px;}
+.popup table tr:nth-child(even) { background-color: #FFCF0940; } /* yellow */
+.popup table tr:nth-child(odd) { background-color: #85B7E740; } /* blue */
+.popup table tr td { font-size: 12px; padding-left: 5px; padding-right: 5px; padding-top: 1px; padding-bottom: 1px; }
+.popup table tr td.ttip { padding-right: 30px; }
+
+.popup .picker { height: auto; padding-right: 5px; }
+
+.popup .tab-content { padding-left: 10px; padding-right: 10px; padding-top: 0px; padding-bottom: 0px; }
+
+.popup .buttons { display: flex; justify-content: space-around; padding: 10px; }
+
+.popup .header { display: flex; padding-left: 10px; padding-right: 10px; padding-top: 0px; padding-bottom: 10px; }
+
+.popup .footer { position: fixed; bottom: 0px; left: 0px; width: 100%; text-align: center; padding: 0px; font-size: 12px; font-weight: bold; }
+
+.popup a { font-size: 115%; }
+
+.popup .ttip:after,.ttip:before { display: block; font-size: 12px; margin-left: 0px; padding-left: 3px; padding-top: 0px; padding-bottom: 0px; text-align: left; }
+
+.popup #messages { margin-top: 0px; margin-bottom: 0px; }
+
+.popup .alert { margin-top: 0px; margin-bottom: 0px; font-size: 12px; }
+

--- a/html/options.html
+++ b/html/options.html
@@ -427,9 +427,7 @@
             </div>
         </div>
         <div id="messages" class="row">
-            <div class="four columns centered text-center">
-                <div class="success alert" data-i18n="optSaved"></div>
-            </div>
+            <div id="msgtxt" class="alert" style="opacity:0">placeholder</div>
         </div>
         <div class="row">
             <div class="twelve columns centered text-center">

--- a/html/popup.html
+++ b/html/popup.html
@@ -5,46 +5,43 @@
     <link rel="stylesheet" href="../css/gumby.css" />
     <link rel="stylesheet" href="../css/style.css" />
     <style type="text/css">
+        /* max size allowed for default popup: 800w x 600h */
         body {
-            width: 400px;
+            height: 600px;
         }
     </style>
     <script src="../js/libs/modernizr-2.7.1.js"></script>
 </head>
 <body>
-    <div class="pretty container">
-        <div class="row">
-            <form>
-                <fieldset>
-                    <legend data-i18n="extName"></legend>
-                    <ul>
-                        <li class="field">
-                            <label class="checkbox" for="chkExtensionDisabled">
-                                <input type="checkbox" id="chkExtensionDisabled"><span></span>
-                                <div id="lblDisable" style="display:inline" data-i18n="popDisableForAllSites"></div>
-                            </label>
-                        </li>
-                        <li class="field">
-                            <label class="checkbox" for="chkExcludeSite">
-                                <input type="checkbox" id="chkExcludeSite"><span></span>
-                                <div id="lblToggle" style="display:inline" data-i18n="popAllowPerSiteToggle"></div>
-                            </label>
-                        </li>
-                    </ul>
-                    <p><a href="#" id="aPreload" style="display: none" data-i18n="popPreloadImages"></a></p>
-                    <p id="lblPreloading" style="display: none"><span id="spanPreloading" data-i18n="popPreloadingImages"></span> <progress id="prgPreloading"></progress></p>
-                </fieldset>
-            </form>
+    <div class="pretty container popup">
+        <div class="header">
+            <div><img src="../images/icon48.png"></div>
+            <h5 data-i18n="optTitle"></h5>
         </div>
-        <div id="footer" class="row">
-            <div class="twelve columns text-right">
-                <a id="aMoreOptions" href="options.html" target="_blank" data-i18n="popMoreOptions"></a>
-            </div>
+        <div>
+            <section>
+                <div class="tab-content active">
+                    <table id="tableActionKeys"></table>
+                </div>
+            </section>
+        </div>
+        <div class="buttons">
+            <div class="small success btn icon-left entypo icon-floppy"><a href="#" id="btnSave" data-i18n="optButtonSave"></a></div>
+            <div class="small warning btn icon-left entypo icon-cancel"><a href="#" id="btnCancel" data-i18n="optButtonCancel"></a></div>
+            <div class="small info btn icon-left entypo icon-arrows-ccw"><a href="#" id="btnReset" data-i18n="optButtonReset"></a></div>
+        </div>
+        <div id="messages" class="row">
+            <div id="msgtxt" class="alert" style="opacity:0">placeholder</div>
+        </div>
+        <div class="footer">
+            <a id="aMoreOptions" href="options.html" target="_blank" data-i18n="popMoreOptions"></a>
         </div>
     </div>
     <script src="../js/libs/backgroundScriptsAPIBridge.js"></script>
     <script src="../js/libs/jquery-3.2.1.js"></script>
     <script src="../js/libs/gumby.js"></script>
+    <script src="../js/libs/spectrum.js"></script>
+    <script src="../js/tools.js"></script>
     <script src="../js/plugins.js"></script>
     <script src="../js/common.js"></script>
     <script src="../js/popup.js"></script>

--- a/js/options.js
+++ b/js/options.js
@@ -138,9 +138,10 @@ function saveOptions() {
     options.useSeparateTabOrWindowForUnloadableUrls = $('#selectUseSeparateTabOrWindowForUnloadableUrls').val();
 
     localStorage.options = JSON.stringify(options);
+
     sendOptions(options);
     restoreOptions();
-    $('#messages').clearQueue().animate({opacity:1}, 500).delay(5000).animate({opacity:0}, 500);
+
     return false;
 }
 
@@ -466,15 +467,34 @@ function initColorPicker(color){
     })
 }
 
+const Saved = Symbol("saved");
+const Cancel = Symbol("cancel");
+const Reset = Symbol("reset");
+function displayMsg(msg) {
+    switch (msg)  {
+        case Saved:
+            $('#msgtxt').removeClass().addClass('centered text-center alert success').text(chrome.i18n.getMessage('optSaved')).clearQueue().animate({opacity:1}, 500).delay(5000).animate({opacity:0}, 500);
+            break;
+        case Cancel:
+            $('#msgtxt').removeClass().addClass('centered text-center alert warning').text(chrome.i18n.getMessage('optCancel')).clearQueue().animate({opacity:1}, 500).delay(5000).animate({opacity:0}, 500);
+            break;
+        case Reset:
+            $('#msgtxt').removeClass().addClass('centered text-center alert info').text(chrome.i18n.getMessage('optReset')).clearQueue().animate({opacity:1}, 500).delay(5000).animate({opacity:0}, 500);
+            break;
+        default:
+            break;
+    }
+}
+
 $(function () {
     initActionKeys();
     i18n();
     chkWhiteListModeOnChange();
     initAddToHistory();
     $("#version").text(chrome.i18n.getMessage("optFooterVersionCopyright", [chrome.runtime.getManifest().version, localStorage['HoverZoomLastUpdate'] ? localStorage['HoverZoomLastUpdate'] : localStorage['HoverZoomInstallation']]));
-    $('#btnSave').click(saveOptions);
-    $('#btnCancel').click(function() { restoreOptions() });
-    $('#btnReset').click(restoreOptionsFromFactorySettings);
+    $('#btnSave').click(function() { saveOptions(); displayMsg(Saved); return false; }); // "return false" needed to prevent page scroll
+    $('#btnCancel').click(function() { restoreOptions(); displayMsg(Cancel); return false; });
+    $('#btnReset').click(function() { restoreOptionsFromFactorySettings(); displayMsg(Reset); return false; });
     $('#chkWhiteListMode').parent().on('gumby.onChange', chkWhiteListModeOnChange);
     $('#txtZoomFactor').change(percentageOnChange);
     $('#txtPicturesOpacity').change(percentageOnChange);

--- a/js/popup.js
+++ b/js/popup.js
@@ -1,114 +1,154 @@
 ﻿var options,
     siteDomain,
-    prgPreloading, lblPreloading, aPreload;
+    prgPreloading, lblPreloading, aPreload,
+    VK_CTRL = 1024,
+    VK_SHIFT = 2048,
+    actionKeys = ['actionKey', 'toggleKey', 'closeKey', 'hideKey', 'openImageInWindowKey', 'openImageInTabKey', 'lockImageKey', 'saveImageKey', 'fullZoomKey', 'prevImgKey', 'nextImgKey', 'flipImageKey', 'copyImageKey', 'copyImageUrlKey'];
+
+function keyCodeToString(key) {
+    var s = '';
+    if (key & VK_CTRL) {
+        s += 'Ctrl+';
+        key &= ~VK_CTRL;
+    }
+    if (key & VK_SHIFT) {
+        s += 'Shift+';
+        key &= ~VK_SHIFT;
+    }
+    if (key >= 65 && key < 91) {
+        s += String.fromCharCode('A'.charCodeAt(0) + key - 65);
+    } else if (key >= 112 && key < 124) {
+        s += 'F' + (key - 111);
+    }
+    return s;
+}
+
+// Options that are only enabled for Chromium-based browsers
+const chromiumOnly = ['copyImageKey', 'copyImageUrlKey'];
+
+function initActionKeys() {
+    actionKeys
+    .filter(key => isChromiumBased || !chromiumOnly.includes(key))
+    .forEach(key => {
+        var id = key[0].toUpperCase() + key.substr(1);
+        var title = chrome.i18n.getMessage("opt" + id + "Title");
+        var description = "opt" + id + "Description";
+        $('<tr><td class="ttip" data-i18n-tooltip="' + description + '">' + title + '</td>' + '<td><select id="sel' + id + '" class="actionKey picker"/></td></tr>').appendTo($('#tableActionKeys'));
+        loadKeys($('#sel' + id));
+    });
+}
+
+function loadKeys(sel) {
+    $('<option value="0">None</option>').appendTo(sel);
+    if (sel.attr('id') != 'lockImageKey')
+        $('<option value="-1">Right Click</option>').appendTo(sel);
+    if (sel.attr('id') != 'selOpenImageInTabKey')
+        $('<option value="16">Shift</option>').appendTo(sel);
+    $('<option value="17">Ctrl</option>').appendTo(sel);
+    if (navigator.appVersion.indexOf('Macintosh') > -1) {
+        $('<option value="91">Command</option>').appendTo(sel);
+    }
+    for (var i = 65; i < 91; i++) {
+        $('<option value="' + i + '">&#' + i + ';</option>').appendTo(sel);
+    }
+    for (var i = 112; i < 124; i++) {
+        $('<option value="' + i + '">F' + (i - 111) + '</option>').appendTo(sel);
+    }
+    $('<option value="27">Escape</option>').appendTo(sel);
+    $('<option value="33">Page Up</option>').appendTo(sel);
+    $('<option value="34">Page Down</option>').appendTo(sel);
+    $('<option value="35">End</option>').appendTo(sel);
+    $('<option value="36">Home</option>').appendTo(sel);
+    $('<option value="37">Left</option>').appendTo(sel);
+    $('<option value="38">Up</option>').appendTo(sel);
+    $('<option value="39">Right</option>').appendTo(sel);
+    $('<option value="40">Down</option>').appendTo(sel);
+    $('<option value="45">Insert</option>').appendTo(sel);
+    $('<option value="46">Delete</option>').appendTo(sel);
+}
+
+// Saves options to localStorage.
+// TODO: Migrate to https://developer.chrome.com/extensions/storage
+function saveOptions() {
+
+    actionKeys.forEach(function(key) {
+        var id = key[0].toUpperCase() + key.substr(1);
+        options[key] = parseInt($('#sel' + id).val());
+    });
+
+    localStorage.options = JSON.stringify(options);
+    sendOptions(options);
+    restoreOptions();
+    return false;
+}
+
+// Restores options from factory settings
+function restoreOptionsFromFactorySettings() {
+    restoreOptions(Object.assign({}, factorySettings));
+}
+
+// Restores options from localStorage.
+function restoreOptions(optionsFromFactorySettings) {
+    options = optionsFromFactorySettings || loadOptions();
+
+    actionKeys.forEach(function(key) {
+        var id = key[0].toUpperCase() + key.substr(1);
+        $('#sel' + id).val(options[key]);
+    });
+
+    return false;
+}
+
+function selKeyOnChange(event) {
+    var currSel = $(event.target);
+    if (currSel.val() != '0') {
+        $('.actionKey').each(function () {
+            if (!$(this).is(currSel) && $(this).val() == currSel.val()) {
+                $(this).val('0').effect("highlight", {color:'red'}, 5000);
+            }
+        });
+    }
+}
+
+const Saved = Symbol("saved");
+const Cancel = Symbol("cancel");
+const Reset = Symbol("reset");
+function displayMsg(msg) {
+    switch (msg)  {
+        case Saved:
+            $('#msgtxt').removeClass().addClass('centered text-center alert success').text(chrome.i18n.getMessage('optSaved')).clearQueue().animate({opacity:1}, 500).delay(5000).animate({opacity:0}, 500);
+            break;
+        case Cancel:
+            $('#msgtxt').removeClass().addClass('centered text-center alert warning').text(chrome.i18n.getMessage('optCancel')).clearQueue().animate({opacity:1}, 500).delay(5000).animate({opacity:0}, 500);
+            break;
+        case Reset:
+            $('#msgtxt').removeClass().addClass('centered text-center alert info').text(chrome.i18n.getMessage('optReset')).clearQueue().animate({opacity:1}, 500).delay(5000).animate({opacity:0}, 500);
+            break;
+        default:
+            break;
+    }
+}
 
 $(function () {
+    initActionKeys();
     i18n();
-
     options = loadOptions();
-    prgPreloading = $('#prgPreloading');
-    lblPreloading = $('#lblPreloading');
 
-    aPreload = $('#aPreload');
-    aPreload.click(aPreloadOnClick);
+    $('#btnSave').click(function() { saveOptions(); displayMsg(Saved); return false; }); // "return false" needed to prevent page scroll
+    $('#btnCancel').click(function() { restoreOptions(); displayMsg(Cancel); return false; });
+    $('#btnReset').click(function() { restoreOptionsFromFactorySettings(); displayMsg(Reset); return false; });
 
-    $('#chkExtensionDisabled').parent().on('gumby.onChange', chkExtensionDisabledOnClick);
+    $('.actionKey').change(selKeyOnChange);
 
-    if (!options.alwaysPreload) {
-        aPreload.css('display', 'inline');
-    }
-
-    chrome.permissions.contains({permissions: ['tabs']}, function (granted) {
-        if (granted) {
-            $('#chkExcludeSite').parent().on('gumby.onChange', chkExcludeSiteOnClick);
-            setTabHook(options);
-        } else {
-            $('#chkExcludeSite').parent().on('gumby.onChange', askTabsPermissions);
-        }
-    });
+    restoreOptions();
 
     chrome.runtime.onMessage.addListener(onMessage);
 });
 
-function askTabsPermissions() {
-    chrome.permissions.contains({permissions: ['tabs']}, function (granted) {
-        if (!granted) {
-            chrome.permissions.request({permissions: ['tabs']}, function (granted) {
-                if (granted) {
-                    setTabHook(options);
-                    window.close();
-                }
-            });
-        }
-    });
-}
-
-function setTabHook(options) {
-    chrome.tabs.query({active: true, currentWindow: true}, function (tabArr) {
-        var tab = tabArr[0];
-        siteDomain = tab.url.split('/', 3)[2];
-        $('#lblToggle').text(chrome.i18n.getMessage(options.whiteListMode ? 'popEnableForSite' : 'popDisableForSite', siteDomain));
-        $('#chkExtensionDisabled')[0].checked = !options.extensionEnabled;
-        $('#chkExcludeSite')[0].checked = isExcludedSite(tab.url);
-        $('input:checked').trigger('gumby.check');
-    });
-}
-
-function chkExtensionDisabledOnClick() {
-    options.extensionEnabled = !$('#chkExtensionDisabled')[0].checked;
-    saveOptions();
-}
-
-function chkExcludeSiteOnClick() {
-    // Get the excluded site index if it has already been added
-    var excludedSiteIndex = -1;
-    for (var i = 0; i < options.excludedSites.length; i++) {
-        if (options.excludedSites[i] == siteDomain) {
-            excludedSiteIndex = i;
-            break;
-        }
-    }
-
-    if ($('#chkExcludeSite')[0].checked) {
-        if (excludedSiteIndex == -1)
-            options.excludedSites.push(siteDomain);
-    } else {
-        if (excludedSiteIndex > -1)
-            options.excludedSites.splice(excludedSiteIndex, 1);
-    }
-
-    saveOptions();
-}
-
-function saveOptions() {
-    localStorage.options = JSON.stringify(options);
-    sendOptions(options);
-}
-
 function onMessage(message, sender, callback) {
     switch (message.action) {
-        case 'preloadAvailable':
-            aPreload.css('display', 'inline');
-            break;
-        case 'preloadProgress':
-            prgPreloading.attr('value', message.value).attr('max', message.max);
-            lblPreloading.css('display', message.value < message.max ? 'inline' : 'none');
-            if (message.value < message.max) {
-                aPreload.css('display', 'none');
-            }
-            break;
-        case 'askTabsPermissions':
-            chrome.permissions.request({permissions: ['tabs']}, function (granted) {
-                callback(granted);
-            });
+        case 'optionsChanged':
+            restoreOptions();
             break;
     }
-}
-
-function aPreloadOnClick() {
-    chrome.tabs.executeScript(null, {code:'if (hoverZoom) { hoverZoom.preloadImages(); }'});
-    aPreload.css('display', 'none');
-    prgPreloading.attr('value', 0).attr('max', 1);
-    lblPreloading.css('display', 'inline');
-    return false;
 }


### PR DESCRIPTION
Some HZ+ users are not aware of existence of action keys and miss out many functionalities (lock, save to disk...).
That's probably because action keys setting is hard to reach, users need to:
- click "Extension menu" puzzle icon
- click "More actions" 3-dots icon
- select "Options" in menu
- select "Action keys" in Options

So i replaced the old popup by a new one for action keys reachable in 2 clicks:
- click "Extension menu" puzzle icon:
![popup1](https://user-images.githubusercontent.com/23529041/155882039-ebafad01-3d28-488f-908c-a58081acba81.png)

- click "Hover Zoom+":
![popup2](https://user-images.githubusercontent.com/23529041/155882055-2a2537a8-fb0b-437e-a9fe-80a043198f14.png)

Note: classic "Action keys" settings in Options are unchanged.
