### PR TITLE
Manifest: Bing plug-in must run in all frames

### DIFF
--- a/_locales/ko/messages.json
+++ b/_locales/ko/messages.json
@@ -44,11 +44,11 @@
         "description": "[options] Page title"
     },
     "optButtonDisableAllPlugins": {
-        "message": "Disable all",
+        "message": "모두 사용 안 함",
         "description": "[options] disable all plugins button label"
     },
     "optButtonEnableAllPlugins": {
-        "message": "Enable all",
+        "message": "모두 사용",
         "description": "[options] enable all plugins button label"
     },
     "optButtonSave": {

--- a/_locales/pt_PT/messages.json
+++ b/_locales/pt_PT/messages.json
@@ -44,11 +44,11 @@
         "description": "[options] Page title"
     },
     "optButtonDisableAllPlugins": {
-        "message": "Disable all",
+        "message": "Desativar todos os plugins",
         "description": "[options] disable all plugins button label"
     },
     "optButtonEnableAllPlugins": {
-        "message": "Enable all",
+        "message": "Ativar todos os plugins",
         "description": "[options] enable all plugins button label"
     },
     "optButtonSave": {

--- a/manifest.json
+++ b/manifest.json
@@ -969,7 +969,8 @@
         },
         {
             "js": ["plugins/bing.js"],
-            "matches": ["*://*.bing.com/*"]
+            "matches": ["*://*.bing.com/*"],
+            "all_frames": true
         },
         {
             "js": ["plugins/xuite.js"],


### PR DESCRIPTION
@extesy you removed **"all_frames": true** directives from manifest for all plug-ins.
This breaks Bing plug-in, so i put it back. Hopefully it does not break any other plug-in...
BTW, why not allowing all plug-ins to run in all frames? 