### PR TITLE
New Advanced option + new plug-in: Dailymotion

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -410,6 +410,14 @@
     "optAddToHistory": {
         "message": "Add viewed pictures to the browser's history",
         "description": "[options] Add viewed pictures to the browser's history option"
+  },
+  "optAllowHeadersRewriteTooltip": {
+    "message": "Useful to be able to zoom & play content from one site on another site, such as videos",
+    "description": "[options] Tooltip for allow rewrite of headers for HTTP(S) request or response option"
+  },
+  "optAllowHeadersRewrite": {
+    "message": "Allow rewrite of headers for HTTP(S) request or response",
+    "description": "[options] Allow rewrite of headers for HTTP(S) request or response option"
     },
     "optFilterNSFW": {
         "message": "Exclude NSFW images (Reddit only)",

--- a/html/options.html
+++ b/html/options.html
@@ -330,6 +330,14 @@
                                         <div style="display:inline" data-i18n="optAddToHistory"></div>
                                     </label>
                                 </li>
+                                <div class="ttip" data-i18n-tooltip="optAllowHeadersRewriteTooltip">
+                                    <li class="field">
+                                        <label class="checkbox" for="chkAllowHeadersRewrite">
+                                            <input type="checkbox" id="chkAllowHeadersRewrite"><span></span>
+                                            <div style="display:inline" data-i18n="optAllowHeadersRewrite"></div>
+                                        </label>
+                                    </li>
+                                </div>
                                 <li class="field">
                                     <label class="checkbox" for="chkFilterNSFW">
                                         <input type="checkbox" id="chkFilterNSFW"><span></span>

--- a/js/common.js
+++ b/js/common.js
@@ -11,6 +11,7 @@ var factorySettings = {
     galleriesMouseWheel : true,
     disableMouseWheelForVideo : false,
     addToHistory : false,
+    allowHeadersRewrite : false,
     alwaysPreload : false,
     displayDelay : 100,
     displayDelayVideo : 500,
@@ -91,6 +92,7 @@ function loadOptions() {
     options.galleriesMouseWheel = options.hasOwnProperty('galleriesMouseWheel') ? options.galleriesMouseWheel : factorySettings.galleriesMouseWheel;
     options.disableMouseWheelForVideo = options.hasOwnProperty('disableMouseWheelForVideo') ? options.disableMouseWheelForVideo : factorySettings.disableMouseWheelForVideo;
     options.addToHistory = options.hasOwnProperty('addToHistory') ? options.addToHistory : factorySettings.addToHistory;
+    options.allowHeadersRewrite = options.hasOwnProperty('allowHeadersRewrite') ? options.allowHeadersRewrite : factorySettings.allowHeadersRewrite;
     options.alwaysPreload = options.hasOwnProperty('alwaysPreload') ? options.alwaysPreload : factorySettings.alwaysPreload;
     options.displayDelay = options.hasOwnProperty('displayDelay') ? options.displayDelay : factorySettings.displayDelay;
     options.displayDelayVideo = options.hasOwnProperty('displayDelayVideo') ? options.displayDelayVideo : factorySettings.displayDelayVideo;
@@ -181,7 +183,7 @@ function isExcludedSite(link) {
     let linkHostname = new URL(link)['hostname'];
     let excluded = !options.whiteListMode;
     for (let i = 0; i < options.excludedSites.length; i++) {
-   
+
         // check if excluded site is included in link hostname
         // e.g:
         // link hostname = www.tiktok.com

--- a/js/options.js
+++ b/js/options.js
@@ -120,6 +120,7 @@ function saveOptions() {
     });
 
     options.addToHistory = $('#chkAddToHistory')[0].checked;
+    options.allowHeadersRewrite = $('#chkAllowHeadersRewrite')[0].checked;
     options.filterNSFW = $('#chkFilterNSFW')[0].checked;
     options.alwaysPreload = $('#chkAlwaysPreload')[0].checked;
     options.enableGalleries = $('#chkEnableGalleries')[0].checked;
@@ -220,6 +221,7 @@ function restoreOptions(optionsFromFactorySettings) {
     });
 
     $('#chkAddToHistory').trigger(options.addToHistory ? 'gumby.check' : 'gumby.uncheck');
+    $('#chkAllowHeadersRewrite').trigger(options.allowHeadersRewrite ? 'gumby.check' : 'gumby.uncheck');
     $('#chkFilterNSFW').trigger(options.filterNSFW ? 'gumby.check' : 'gumby.uncheck');
     $('#chkAlwaysPreload').trigger(options.alwaysPreload ? 'gumby.check' : 'gumby.uncheck');
     $('#chkEnableGalleries').trigger(options.enableGalleries ? 'gumby.check' : 'gumby.uncheck');
@@ -362,6 +364,25 @@ function initAddToHistory() {
             $('#chkAddToHistory').parent().on('gumby.onChange', chkAddToHistoryModeOnChange);
         }
     });
+}
+
+function chkAllowHeadersRewriteOnChange() {
+    if ($('#chkAllowHeadersRewrite')[0].checked) {
+        chrome.permissions.contains({permissions: ['webRequest','webRequestBlocking']}, function (granted) { 
+            if (!granted) {
+                // ask user for permissions
+                chrome.permissions.request({permissions: ['webRequest','webRequestBlocking']}, function (granted) {
+                    if (!granted) {
+                        $('#chkAddToHistory').trigger('gumby.uncheck');
+                    }
+                });
+            }
+        });
+    }
+}
+
+function initAllowHeadersRewrite() {
+    $('#chkAllowHeadersRewrite').parent().on('gumby.onChange', chkAllowHeadersRewriteOnChange);
 }
 
 function percentageOnChange(val) {
@@ -558,6 +579,7 @@ $(function () {
     i18n();
     chkWhiteListModeOnChange();
     initAddToHistory();
+    initAllowHeadersRewrite();
     $("#version").text(chrome.i18n.getMessage("optFooterVersionCopyright", [chrome.runtime.getManifest().version, localStorage['HoverZoomLastUpdate'] ? localStorage['HoverZoomLastUpdate'] : localStorage['HoverZoomInstallation']]));
     $('#btnSave').click(function() { removeModifications(); saveOptions(); displayMsg(Saved); return false; }); // "return false" needed to prevent page scroll
     $('#btnCancel').click(function() { removeModifications(); restoreOptions(); displayMsg(Cancel); return false; });

--- a/manifest.json
+++ b/manifest.json
@@ -37,7 +37,9 @@
     "optional_permissions": [
         "downloads",
         "history",
-        "tabs"
+        "tabs",
+        "webRequest",
+        "webRequestBlocking"
     ],
     "web_accessible_resources": [
         "images/loading.gif",
@@ -74,6 +76,7 @@
                 "plugins/cloudapp_a.js",
                 "plugins/cloudfront_a.js",
                 "plugins/cloudinary_a.js",
+                "plugins/dailymotion_a.js",
                 "plugins/deviantart_a.js",
                 "plugins/ebay_a.js",
                 "plugins/facebook_a.js",

--- a/plugins/dailymotion_a.js
+++ b/plugins/dailymotion_a.js
@@ -1,0 +1,188 @@
+﻿var hoverZoomPlugins = hoverZoomPlugins || [];
+hoverZoomPlugins.push( {
+    name: 'dailymotion_a',
+    version: '1.1',
+    prepareImgLinks: function(callback) {
+        var name = this.name;
+
+        // if header(s) rewrite is allowed store settings defined above
+        if (options.allowHeadersRewrite) {
+            chrome.runtime.sendMessage({action:"storeHeaderSettings",
+                                        requestOrResponse:"request",
+                                        skipInitiator:"dailymotion",
+                                        url:"dailymotion.com",
+                                        headers:[{name:"referer", value:"https://www.dailymotion.com/", typeOfUpdate:"add"}]});
+            chrome.runtime.sendMessage({action:"storeHeaderSettings",
+                                        requestOrResponse:"response",
+                                        skipInitiator:"dailymotion",
+                                        url:"dailymotion.com",
+                                        headers:[{name:"Access-Control-Allow-Origin", value:"*", typeOfUpdate:"add"}]});
+        }
+
+        // users
+        // sample: https://www.dailymotion.com/CanalplusSport
+        $('a[href]').filter(function() { return (/dailymotion\.com\/[^\/]{1,}$/.test($(this).prop('href'))) }).on('mouseover', function() {
+            var link = undefined;
+            var href = undefined;
+
+            href = this.href;
+            link = $(this);
+
+            const re = /dailymotion\.com\/([^\/\?]{1,})$/;   // user (e.g. CanalplusSport)
+            m = href.match(re);
+            if (m == undefined) return;
+            let user = m[1];
+
+            // reuse previous result
+            if (link.data().hoverZoomDailyMotionUser == user) {
+                if (link.data().hoverZoomDailyMotionUserUrl) link.data().hoverZoomSrc = [link.data().hoverZoomDailyMotionUserUrl];
+                return;
+            }
+
+            link.data().hoverZoomDailyMotionUser = user;
+            link.data().hoverZoomDailyMotionUserUrl = undefined;
+
+            // clean previous result
+            link.data().hoverZoomSrc = [];
+            getUserFromAPI(user, link);
+        })
+
+        function getUserFromAPI(user, link) {
+            chrome.runtime.sendMessage({action:'ajaxRequest',
+                                        method:'GET',
+                                        url:'https://api.dailymotion.com/user/' + user + '?fields=avatar_720_url',
+                                        headers:[{"header":"Content-Type","value":"application/json"}]},
+                                        function (response) {
+                                            if (response) {
+                                                try {
+                                                    let j = JSON.parse(response);
+                                                    let userUrl = j.avatar_720_url;
+                                                    if (userUrl) {
+                                                        link.data().hoverZoomDailyMotionUserUrl = userUrl;
+                                                        link.data().hoverZoomSrc = [userUrl];
+                                                        callback(link, name);
+                                                        hoverZoom.displayPicFromElement(link);
+                                                    }
+                                                } catch {}
+                                            }
+                                        });
+        }
+
+        // playlists
+        // sample: https://www.dailymotion.com/playlist/x7292h
+        $('a[href*="/playlist/"]').filter(function() { return (/dailymotion\.com\/playlist\//.test($(this).prop('href'))) }).on('mouseover', function() {
+            var link = undefined;
+            var href = undefined;
+
+            href = this.href;
+            link = $(this);
+
+            const re = /dailymotion\.com\/playlist\/([^\/\?]{1,})/;   // playlist id (e.g. x7292h)
+            m = href.match(re);
+            if (m == undefined) return;
+            let playlistId = m[1];
+
+            // reuse previous result
+            if (link.data().hoverZoomDailyMotionPlaylistId == playlistId) {
+                if (link.data().hoverZoomDailyMotionPlaylistUrls) link.data().hoverZoomGallerySrc = link.data().hoverZoomDailyMotionPlaylistUrls;
+                return;
+            }
+
+            link.data().hoverZoomDailyMotionPlaylistId = playlistId;
+            link.data().hoverZoomDailyMotionPlaylistUrls = [];
+
+            // clean previous result
+            link.data().hoverZoomSrc = [];
+            getPlaylistFromAPI(playlistId, link);
+        })
+
+        function getPlaylistFromAPI(playlistId, link) {
+            chrome.runtime.sendMessage({action:'ajaxRequest',
+                                        method:'GET',
+                                        url:'https://api.dailymotion.com/playlist/' + playlistId + '/videos?limit=100',
+                                        headers:[{"header":"Content-Type","value":"application/json"}]},
+                                        function (response) {
+                                            try {
+                                                let j = JSON.parse(response);
+                                                let nb = j.list.length;
+                                                for (let i = 0; i < nb; i++) {
+                                                    let videoId = j.list[i].id;
+                                                    getVideosFromAPI(videoId, link, nb, i);
+                                                }
+                                            } catch {}
+                                        });
+        }
+
+        // videos
+        // sample: https://www.dailymotion.com/video/x8994nm
+        $('a[href*="/video/"]').filter(function() { return (/dailymotion\.com(\/embed)?\/video\//.test($(this).prop('href'))) }).on('mouseover', function() {
+            var link = undefined;
+            var href = undefined;
+
+            href = this.href;
+            link = $(this);
+
+            const re = /dailymotion\.com(?:\/embed)?\/video\/([^\/\?]{1,})/;   // video id (e.g. x8994nm)
+            m = href.match(re);
+            if (m == undefined) return;
+            let videoId = m[1];
+
+            // reuse previous result
+            if (link.data().hoverZoomDailyMotionVideoId == videoId) {
+                if (link.data().hoverZoomDailyMotionVideoUrl) link.data().hoverZoomSrc = [link.data().hoverZoomDailyMotionVideoUrl];
+                return;
+            }
+
+            link.data().hoverZoomDailyMotionVideoId = videoId;
+            link.data().hoverZoomDailyMotionVideoUrl = undefined;
+
+            // clean previous result
+            link.data().hoverZoomSrc = [];
+            getVideoFromAPI(videoId, link);
+        })
+
+        function getVideoFromAPI(videoId, link) {
+            chrome.runtime.sendMessage({action:'ajaxRequest',
+                                        method:'GET',
+                                        url:'https://www.dailymotion.com/player/metadata/video/' + videoId,
+                                        headers:[{"header":"Content-Type","value":"application/json"}]},
+                                        function (response) {
+                                            try {
+                                                let j = JSON.parse(response);
+                                                let videoUrl = j.qualities.auto[0].url;
+                                                if (videoUrl) {
+                                                    link.data().hoverZoomDailyMotionVideoUrl = videoUrl;
+                                                    link.data().hoverZoomSrc = [videoUrl];
+                                                    callback(link, name);
+                                                    hoverZoom.displayPicFromElement(link);
+                                                }
+                                            } catch {}
+                                        });
+        }
+
+        function getVideosFromAPI(videoId, link, nb, idx) {
+            chrome.runtime.sendMessage({action:'ajaxRequest',
+                                        method:'GET',
+                                        url:'https://www.dailymotion.com/player/metadata/video/' + videoId,
+                                        headers:[{"header":"Content-Type","value":"application/json"}]},
+                                        function (response) {
+                                            try {
+                                                let j = JSON.parse(response);
+                                                let videoUrl = j.qualities.auto[0].url;
+                                                if (videoUrl) {
+                                                    link.data().hoverZoomDailyMotionPlaylistUrls.push({'videoUrl':videoUrl, 'idx':idx});
+                                                    if (link.data().hoverZoomGallerySrc.length == nb) {
+                                                        // sort urls
+                                                        link.data().hoverZoomDailyMotionPlaylistUrls = link.data().hoverZoomDailyMotionPlaylistUrls.sort(function(a,b) { if (parseInt(a.idx) < parseInt(b.idx)) return -1; return 1;}).map(o => [o.videoUrl]);
+                                                        link.data().hoverZoomGallerySrc = link.data().hoverZoomDailyMotionPlaylistUrls;
+                                                        link.data().hoverZoomSrc = undefined;
+                                                        link.addClass('hoverZoomLinkFromPlugIn');
+                                                        callback(link, name);
+                                                        hoverZoom.displayPicFromElement(link);
+                                                    }
+                                                }
+                                            } catch {}
+                                        });
+        }
+    }
+});


### PR DESCRIPTION
There's a new Advanced option: 
![option_CORS](https://user-images.githubusercontent.com/23529041/169506200-b428f99c-79b4-48b3-adc5-37727c149ddc.jpg)
By default, this option is **disabled**.
When enabled, HZ+ can now deal with CORS mechanism, as if a specific extension such as SMH (https://chrome.google.com/webstore/detail/simple-modify-headers/gjgiipmpldkpbdfjkgofildhapegmmic), was installed along with HZ+. (Note: SMH is used with Imagus)

The big benefit is that users do not have to install & tweak SMH or similar tool - which is a tedious task - because plug-ins will handle headers rewrite by themselves. 
For now, the only plug-in that uses this feature is **Dailymotion**. As a result, videos from Dailymotion can be zoomed & played from Google & Bing search pages, from Reddit & other sites.

2 optional permissions are added to manifest:
"**webRequest**"
"**webRequestBlocking**"
These permissions are needed to rewrite HTTP(S) request or response headers "on the fly", when they leave or enter the browser.