### PR TITLE
New warning message when page is not focused

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -718,5 +718,9 @@
     "msgClickPageToPlayVideo": {
         "message": "Click anywhere on the page then hover again",
         "description": "User must interact with the document first to play video: https://goo.gl/xX8pDD"
+    },
+    "msgClickPageToActivateActionKeys": {
+        "message": "click anywhere on the page to activate action keys",
+        "description": "Action keys are active only if page is focused"
     }
 }


### PR DESCRIPTION
Sometimes action keys seem to be broken, this usually happens when page has lost focus.
A warning message will ask user to click anywhere on page so it has focus and action keys can work.
This message is displayed only once (until page is reloaded), so users that do not use action keys are not bothered.

![msg](https://user-images.githubusercontent.com/23529041/171850589-f1738f2a-c60b-4834-a2c8-d9890b49421d.png)

