### PR TITLE
Remove source mapping comment from hls.js

### DIFF
--- a/js/hls.js
+++ b/js/hls.js
@@ -27801,4 +27801,3 @@ var XhrLoader = /*#__PURE__*/function () {
 
 /******/ })["default"];
 });
-//# sourceMappingURL=hls.js.map


### PR DESCRIPTION
Removes this warning from the console.

![image](https://user-images.githubusercontent.com/709773/186052118-37f7df5a-2f3c-4f71-a290-aac31df2914f.png)
For most users it's likely not an issue, for web developers it's a pain having it log out to the console.