### PR TITLE
Add a link to the list of plugins in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Hover Zoom+
 ===========
 
-Zoom images/videos on all your favorite websites (Facebook, Amazon, etc). Hover your mouse over any image on the supported websites and the extension will automatically enlarge the image to its full size, making sure that it still fits into the browser window.
+Zoom images/videos on all your favorite websites (Facebook, Amazon, etc). Hover your mouse over any image on the [supported websites](https://github.com/extesy/hoverzoom/tree/master/plugins) and the extension will automatically enlarge the image to its full size, making sure that it still fits into the browser window.
 
 This is an open source version of the original HoverZoom extension which is now overrun by malware and deleted from store. In this version all spyware has been removed, many bugs were fixed and new features were added. It doesn't collect any statistics whatsoever. The only permission it needs is to access data on all websites (to extract full images), and *optional* permissions to access browser history, download/save images or get tab urls for per-site configuration.
 


### PR DESCRIPTION
The list of supported sites is not easy to find. This is obvious to you as the author, but I needed to go from the addons page to the repository, read the readme, enter a query into the search, and only on the second page of results I understand that each supported site is a separate file in the plugins folder. It took some time. And not every addon user will be able to find it. But I think a lot of people will. 

This PR is just a simple example of how you can help the user find the list. But this is a bad solution to the problem. I would recommend that you provide a link to such information on the addon page. You can also add a list opening from an already installed addon.