### PR TITLE
Fix for missing file extension after download (#1116)

### DIFF
--- a/js/hoverzoom.js
+++ b/js/hoverzoom.js
@@ -2799,12 +2799,18 @@ var hoverZoom = {
                 cLog('filename: ' + filename);
             }
 
-            chrome.runtime.sendMessage({
-                action: 'downloadFile',
-                url: url,
-                filename: filename,
-                conflictAction: 'uniquify'
-            }, callback);
+            // 1st attempt to download file (Chrome API)
+            chrome.runtime.sendMessage({action:'downloadFile',
+                                        url:url,
+                                        filename:filename,
+                                        conflictAction:'uniquify'},
+                                        function() {
+                                            // 2nd attempt (blob + Chrome API)
+                                            chrome.runtime.sendMessage({action:'downloadFileBlob',
+                                                                        url:url,
+                                                                        filename:filename,
+                                                                        conflictAction:'uniquify'});
+                                        });
         }
 
         // 4 types of media can be saved to disk: image, video, audio, playlist


### PR DESCRIPTION
HZ+ first tries to download a file using Chrome API (chrome.downloads.download).
Download **will succeed in most cases** and downloaded files will have correct extensions, even if  "Double-click Image Downloader" or "image Downloader" extensions are active.


But some sites prevent direct download, such as Pixiv, so if download fails then HZ+ will use a workaround:
1. obtain ArrayBuffer from XHR request (GET URL)
2. create Blob from ArrayBuffer
3. download Blob URL through Chrome API (chrome.downloads.download)

Then 2 cases:
- "Double-click Image Downloader" or "image Downloader" extensions are NOT active: file extensions are correct.
- "Double-click Image Downloader" or "image Downloader" extensions are active: file extensions are missing, they must be added by hand.
