### PR TITLE
Fix for multiple downloads when saving a file (#1127)

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -82,7 +82,7 @@ function onMessage(message, sender, callback) {
                     chrome.downloads.onChanged.removeListener(onChanged);
                     // call callback only if download failed
                     if (delta.state.current !== 'complete') {
-                        callback();
+                        callback(true);
                     }
                 }
             }

--- a/js/hoverzoom.js
+++ b/js/hoverzoom.js
@@ -2806,12 +2806,14 @@ var hoverZoom = {
                                         url:url,
                                         filename:filename,
                                         conflictAction:'uniquify'},
-                                        function() {
-                                            // 2nd attempt (blob + Chrome API)
-                                            chrome.runtime.sendMessage({action:'downloadFileBlob',
-                                                                        url:url,
-                                                                        filename:filename,
-                                                                        conflictAction:'uniquify'});
+                                        function (downloadKO) {
+                                            if (downloadKO) {
+                                                // 2nd attempt (blob + Chrome API)
+                                                chrome.runtime.sendMessage({action:'downloadFileBlob',
+                                                                            url:url,
+                                                                            filename:filename,
+                                                                            conflictAction:'uniquify'});
+                                            }
                                         });
         }
 


### PR DESCRIPTION
Sometimes, for some unknown reason, callback for download retry is called even if download succeded.
=> protection added against "parasite" callback calls