### PR TITLE
Improvement for zoom in/out on locked images & videos

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -383,6 +383,34 @@
         "message": "sec",
         "description": "[options] Short form of \"second\" for delay duration"
     },
+    "optSectionZoomSpeed": {
+        "message": "Zoom speed",
+        "description": "[options] Page section for zoom speed"
+    },
+    "optZoomSpeed_P1": {
+        "message": "When an image or video is locked on screen, it can be zoomed in or out using mouse wheel.",
+        "description": "[options] Zoom speed Part 1"
+    },
+    "optZoomSpeed_P2": {
+        "message": "press",
+        "description": "[options] Zoom speed Part 2"
+    },
+    "optZoomSpeed_P3": {
+        "message": "or",
+        "description": "[options] Zoom speed Part 3"
+    },
+    "optZoomSpeed_P4": {
+        "message": " while scrolling to zoom",
+        "description": "[options] Zoom speed Part 4"
+    },
+    "optZoomSpeed_P41": {
+        "message": "faster",
+        "description": "[options] Zoom speed Part 41"
+    },
+    "optZoomSpeed_P42": {
+        "message": "slower",
+        "description": "[options] Zoom speed Part 42"
+    },
     "optPagePlugins": {
         "message": "Plugins",
         "description": "[options] Page title for plugin options"

--- a/html/options.html
+++ b/html/options.html
@@ -305,6 +305,34 @@
                                 </div>
                             </ul>
                         </fieldset>
+                        <fieldset>
+                            <legend data-i18n="optSectionZoomSpeed"></legend>
+                            <ul>
+                                <div data-i18n="optZoomSpeed_P1" class="faq question"></div>
+                                <ol>
+                                    <li style="list-style-type:disc">
+                                        <div class="faq answer">
+                                            <div data-i18n="optZoomSpeed_P2"></div>
+                                            <div class="btn default"><a>&#43;</a></div>
+                                            <div data-i18n="optZoomSpeed_P3"></div>
+                                            <div class="btn default"><a>&#8593;</a></div>
+                                            <div data-i18n="optZoomSpeed_P4"></div>
+                                            <strong><div data-i18n="optZoomSpeed_P41"></div></strong>
+                                        </div>
+                                    </li>
+                                    <li style="list-style-type:disc">
+                                        <div class="faq answer">
+                                            <div data-i18n="optZoomSpeed_P2"></div>
+                                            <div class="btn default"><a>&#8722;</a></div>
+                                            <div data-i18n="optZoomSpeed_P3"></div>
+                                            <div class="btn default"><a>&#8595;</a></div>
+                                            <div data-i18n="optZoomSpeed_P4"></div>
+                                            <strong><div data-i18n="optZoomSpeed_P42"></div></strong>
+                                        </div>
+                                    </li>
+                                </ol>
+                            </ul>
+                        </fieldset>
                     </form>
                 </div>
                 <div class="tab-content">

--- a/js/hoverzoom.js
+++ b/js/hoverzoom.js
@@ -119,9 +119,14 @@ var hoverZoom = {
             actionKeyDown = false,
             fullZoomKeyDown = false,
             hideKeyDown = false,
+            plusKeyDown = false,
+            minusKeyDown = false,
+            arrowUpKeyDown = false,
+            arrowDownKeyDown = false,
             viewerLocked = false,
             lockViewerClickTime = 0,
             zoomFactor = 1,
+            zoomSpeedFactor = 1,
             pageActionShown = false,
             skipFadeIn = false,
             titledElements = null,
@@ -2159,6 +2164,13 @@ var hoverZoom = {
                 // For large imgs (= width or height > 1000px), a smaller step is needed
                 let stepInit = 0.1 / (1.0 + Math.floor(Math.max(srcDetails.naturalWidth, srcDetails.naturalHeight) / 1000.0));
                 let step = zoomFactor < 2 ? stepInit : stepInit * Math.floor(zoomFactor);
+                if (plusKeyDown || arrowUpKeyDown) {
+                    zoomSpeedFactor *= 2.0;
+                }
+                if (minusKeyDown || arrowDownKeyDown) {
+                    zoomSpeedFactor *= 0.5;
+                }
+                step *= zoomSpeedFactor;
                 zoomFactor = zoomFactor + (event.deltaY < 0 ? 1 : -1) * step;
                 zoomFactor = Math.max(Math.min(zoomFactor, 10), stepInit);
                 posViewer();
@@ -2313,6 +2325,34 @@ var hoverZoom = {
                     flipImage();
                     return false;
                 }
+                // "+" key is pressed
+                if (event.which == 107) {
+                    event.preventDefault();
+                    plusKeyDown = true;
+                    zoomSpeedFactor = 1; // reset zoom speed factor on locked images & videos
+                    return false;
+                }
+                // "-" key is pressed
+                if (event.which == 109) {
+                    event.preventDefault();
+                    minusKeyDown = true;
+                    zoomSpeedFactor = 1; // reset zoom speed factor on locked images & videos
+                    return false;
+                }
+                // "Arrow Up" key is pressed
+                if (event.which == 38) {
+                    event.preventDefault();
+                    arrowUpKeyDown = true;
+                    zoomSpeedFactor = 1; // reset zoom speed factor on locked images & videos
+                    return false;
+                }
+                // "Arrow Down" key is pressed
+                if (event.which == 40) {
+                    event.preventDefault();
+                    arrowDownKeyDown = true;
+                    zoomSpeedFactor = 1; // reset zoom speed factor on locked images & videos
+                    return false;
+                }
             }
         }
 
@@ -2370,6 +2410,30 @@ var hoverZoom = {
                 if (keyCode === options.saveImageKey) {
                     saveImage();
                     return false;
+                }
+                // "+" key is released
+                if (event.which == 107) {
+                    event.preventDefault();
+                    plusKeyDown = false;
+                    zoomSpeedFactor = 1; // reset zoom speed factor on locked images & videos
+                }
+                // "-" key is released
+                if (event.which == 109) {
+                    event.preventDefault();
+                    minusKeyDown = false;
+                    zoomSpeedFactor = 1; // reset zoom speed factor on locked images & videos
+                }
+                // "Arrow Up" key is released
+                if (event.which == 38) {
+                    event.preventDefault();
+                    arrowUpKeyDown = false;
+                    zoomSpeedFactor = 1; // reset zoom speed factor on locked images & videos
+                }
+                // "Arrow Down" key is released
+                if (event.which == 40) {
+                    event.preventDefault();
+                    arrowDownKeyDown = false;
+                    zoomSpeedFactor = 1; // reset zoom speed factor on locked images & videos
                 }
             }
         }


### PR DESCRIPTION
When an image or video is locked on screen, it can be zoomed in or out using mouse wheel.

- press + or ↑ while scrolling to zoom **faster**
- press − or ↓ while scrolling to zoom **slower**

Update of options page:

![image](https://github.com/extesy/hoverzoom/assets/23529041/985a4e97-7d21-4b5b-ae1e-f387b603badf)
