### PR TITLE
Fix for plug-in : Shein (#1203)

### DIFF
--- a/plugins/shein.js
+++ b/plugins/shein.js
@@ -1,27 +1,32 @@
 ﻿var hoverZoomPlugins = hoverZoomPlugins || [];
 hoverZoomPlugins.push( {
     name: 'shein',
-    version: '1.0',
+    version: '1.1',
+    favicon:'shein.ico',
     prepareImgLinks: function(callback) {
-        var res = [];
 
-        // sample:   https://img.ltwebstatic.com/images3_pi/2022/01/06/164143298217b45c1da8a1c07351af19a5ff72327e_thumbnail_220x293.webp
-        // fullsize: https://img.ltwebstatic.com/images3_pi/2022/01/06/164143298217b45c1da8a1c07351af19a5ff72327e.webp
-        hoverZoom.urlReplace(res,
-            'img[src],div',
-            /_thumbnail.*\./,
-            '.',
-            'a'
-        );
-        
-        // sample:   https://img.ltwebstatic.com/images3_pi/2022/01/06/164143298217b45c1da8a1c07351af19a5ff72327e_thumbnail_220x293.webp
-        // fullsize: https://img.ltwebstatic.com/images3_pi/2022/01/06/164143298217b45c1da8a1c07351af19a5ff72327e.webp
-        hoverZoom.urlReplace(res,
-            'img[src],div',
-            /_thumbnail.*\./,
-            '.'
-        );
+        $('img[data-src], img[src*="_thumbnail"]').one('mouseover', function() {
+            const src = this.dataset.src || this.src;
+            const link = $(this);
+            const largeUrl = src.replace(/_thumbnail.*\./, '.');
+            link.data().hoverZoomSrc = [largeUrl];
+            link.addClass('hoverZoomLink');
+            callback(link, this.name);
+            hoverZoom.displayPicFromElement(link);
+        });
 
-        callback($(res), this.name);
+        // deals with cover-protection (#1203)
+        $('.cover-frame').one('mouseover', function() {
+            const link = $(this);
+            if (link.siblings('img:not(.lazyload)').length != 1) return;
+            const img = link.siblings('img:not(.lazyload)')[0];
+            const src = img.dataset.src || img.src;
+            const largeUrl = src.replace(/_thumbnail.*\./, '.');
+            link.data().hoverZoomSrc = [largeUrl];
+            link.addClass('hoverZoomLink');
+            callback(link, this.name);
+            hoverZoom.displayPicFromElement(link);
+        });
+
     }
 });


### PR DESCRIPTION
This fix addresses cover-protection in order to let users save full-size images.