### PR TITLE
add support for woot.com

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1975,6 +1975,10 @@
         {
             "js": ["plugins/vsco.js"],
             "matches": ["*://*.vsco.co/*"]
+        },
+        {
+            "js": ["plugins/shirt_woot.js"],
+            "matches": ["*://shirt.woot.com/*"]
         }
     ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1977,8 +1977,8 @@
             "matches": ["*://*.vsco.co/*"]
         },
         {
-            "js": ["plugins/shirt_woot.js"],
-            "matches": ["*://shirt.woot.com/*"]
+            "js": ["plugins/woot.js"],
+            "matches": ["*://*.woot.com/*"]
         }
     ]
 }

--- a/plugins/shirt_woot.js
+++ b/plugins/shirt_woot.js
@@ -1,0 +1,14 @@
+var hoverZoomPlugins = hoverZoomPlugins || [];
+hoverZoomPlugins.push({
+    name: 'shirt.woot.com',
+    version: '0.1',
+    prepareImgLinks(callback) {
+        const res = [];
+        hoverZoom.urlReplace(res,
+            'a img',
+            '._SX240_.',
+            '.');
+
+        callback($(res), this.name);
+    },
+});

--- a/plugins/woot.js
+++ b/plugins/woot.js
@@ -5,7 +5,7 @@ hoverZoomPlugins.push({
     prepareImgLinks(callback) {
         const res = [];
         hoverZoom.urlReplace(res,
-            'a img',
+            'ul.product-grid a img',
             /\._.*_\./,
             '.');
 

--- a/plugins/woot.js
+++ b/plugins/woot.js
@@ -3,14 +3,13 @@ hoverZoomPlugins.push({
     name: 'woot.com',
     version: '0.1',
     prepareImgLinks(callback) {
-
         const res = [];
-        const thumbnailRegex =  /\._.*_\./;
+        const thumbnailRegex = /\._.*_\./;
 
         // All images are thumbnails: https://shirt.woot.com/plus/derby-editors-choice-sportsball-1?ref=w_cnt_wp_1
         // Some images are not thumbnails, but full size: https://www.woot.com/category/computers/desktops?ref=w_cnt_cdet_pc_2
-        $('ul a img').each(function() {
-            const src = this.src;
+        $('ul a img').each(function handleNestedImages() {
+            const { src } = this;
             const link = $(this);
             const fullsize = src.replace(thumbnailRegex, '.');
 
@@ -20,8 +19,8 @@ hoverZoomPlugins.push({
         });
 
         // Div overlay: https://www.woot.com/alldeals?ref=w_ngh_et_1
-        $('a div img').each(function() {
-            const src = this.src;
+        $('a div img').each(function handleDivOverlay() {
+            const { src } = this;
             const link = $(this);
             const fullsize = src.replace(thumbnailRegex, '.');
 

--- a/plugins/woot.js
+++ b/plugins/woot.js
@@ -1,5 +1,4 @@
 var hoverZoomPlugins = hoverZoomPlugins || [];
-console.log("loaded woot");
 hoverZoomPlugins.push({
     name: 'woot.com',
     version: '0.1',

--- a/plugins/woot.js
+++ b/plugins/woot.js
@@ -25,9 +25,11 @@ hoverZoomPlugins.push({
             const fullsize = src.replace(thumbnailRegex, '.');
 
             const divOverlay = link.parent().next('div');
-            divOverlay.data().hoverZoomSrc = [fullsize];
-            divOverlay.addClass('hoverZoomLink');
-            res.push(divOverlay);
+            if (divOverlay[0]) {
+                divOverlay.data().hoverZoomSrc = [fullsize];
+                divOverlay.addClass('hoverZoomLink');
+                res.push(divOverlay);
+            }
         });
 
         callback($(res), this.name);

--- a/plugins/woot.js
+++ b/plugins/woot.js
@@ -3,11 +3,33 @@ hoverZoomPlugins.push({
     name: 'woot.com',
     version: '0.1',
     prepareImgLinks(callback) {
+
         const res = [];
-        hoverZoom.urlReplace(res,
-            'ul.product-grid a img',
-            /\._.*_\./,
-            '.');
+        const thumbnailRegex =  /\._.*_\./;
+
+        // All images are thumbnails: https://shirt.woot.com/plus/derby-editors-choice-sportsball-1?ref=w_cnt_wp_1
+        // Some images are not thumbnails, but full size: https://www.woot.com/category/computers/desktops?ref=w_cnt_cdet_pc_2
+        $('ul a img').each(function() {
+            const src = this.src;
+            const link = $(this);
+            const fullsize = src.replace(thumbnailRegex, '.');
+
+            link.data().hoverZoomSrc = [fullsize];
+            link.addClass('hoverZoomLink');
+            res.push(link);
+        });
+
+        // Div overlay: https://www.woot.com/alldeals?ref=w_ngh_et_1
+        $('a div img').each(function() {
+            const src = this.src;
+            const link = $(this);
+            const fullsize = src.replace(thumbnailRegex, '.');
+
+            const divOverlay = link.parent().next('div');
+            divOverlay.data().hoverZoomSrc = [fullsize];
+            divOverlay.addClass('hoverZoomLink');
+            res.push(divOverlay);
+        });
 
         callback($(res), this.name);
     },

--- a/plugins/woot.js
+++ b/plugins/woot.js
@@ -1,12 +1,13 @@
 var hoverZoomPlugins = hoverZoomPlugins || [];
+console.log("loaded woot");
 hoverZoomPlugins.push({
-    name: 'shirt.woot.com',
+    name: 'woot.com',
     version: '0.1',
     prepareImgLinks(callback) {
         const res = [];
         hoverZoom.urlReplace(res,
             'a img',
-            '._SX240_.',
+            /\._.*_\./,
             '.');
 
         callback($(res), this.name);


### PR DESCRIPTION
Sample URL: https://shirt.woot.com/plus/5-shirts-for-30

![image](https://github.com/extesy/hoverzoom/assets/857700/3f730152-5b99-4c37-997e-7f402711ea64)

All the images have a `._SX240_` suffix, wasn't sure the best way to replace it, but this worked. Open to suggestions.