### PR TITLE
Fix mediawiki plugin thumbnail selector

### DIFF
--- a/plugins/mediawiki_a.js
+++ b/plugins/mediawiki_a.js
@@ -8,7 +8,7 @@ hoverZoomPlugins.push({
 
         // thumbnail: /images/thumb/2/26/Senntisten_Kree%27arra_vs_Nodon.png/534px-Senntisten_Kree%27arra_vs_Nodon.png?de6e2
         //  fullsize: https://runescape.wiki/images/2/26/Senntisten_Kree%27arra_vs_Nodon.png
-        $('img[src*="thumb/"], image[href*="wiki"]').each(function() {
+        $('.mediawiki img[src*="thumb/"], image[href*="wiki"]').each(function() {
             let _this = $(this);
             let src = '';
             let srcs = [];

--- a/plugins/mediawiki_a.js
+++ b/plugins/mediawiki_a.js
@@ -6,9 +6,9 @@ hoverZoomPlugins.push({
     prepareImgLinks:function (callback) {
         var res = [];
 
-        // thumbnail: https://runescape.wiki/images/thumb/2/26/Senntisten_Kree%27arra_vs_Nodon.png/534px-Senntisten_Kree%27arra_vs_Nodon.png?de6e2
+        // thumbnail: /images/thumb/2/26/Senntisten_Kree%27arra_vs_Nodon.png/534px-Senntisten_Kree%27arra_vs_Nodon.png?de6e2
         //  fullsize: https://runescape.wiki/images/2/26/Senntisten_Kree%27arra_vs_Nodon.png
-        $('img[src*="wiki"][src*="thumb/"], image[href*="wiki"]').each(function() {
+        $('img[src*="thumb/"], image[href*="wiki"]').each(function() {
             let _this = $(this);
             let src = '';
             let srcs = [];


### PR DESCRIPTION
Use a less precise attribute selector since mediawiki thumbnail URLs no longer use the full URL

E.g. https://runescape.wiki/