### PR TITLE
New option: add index of image in gallery when saving

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -571,6 +571,14 @@
         "message": "duration",
         "description": "[options] Add download duration option"
     },
+    "optAddDownloadIndexTooltip": {
+        "message": "Add index of image in gallery (e.g: third image out of ten: 03-10)",
+        "description": "[options] Tooltip for add download index option"
+    },
+    "optAddDownloadIndex": {
+        "message": "index",
+        "description": "[options] Add download index option"
+    }, 
     "optSectionTroubleshooting": {
         "message": "Troubleshooting",
         "description": "[options] Page section for troubleshooting"

--- a/html/options.html
+++ b/html/options.html
@@ -448,7 +448,7 @@
                                     </div>
                                     <div class="ttip" data-i18n-tooltip="optAddDownloadOriginTooltip">
                                         <div class="field">
-                                            <label class="checkbox" style="padding-right:100px" for="chkAddDownloadOrigin">
+                                            <label class="checkbox" style="padding-right:10px" for="chkAddDownloadOrigin">
                                                 <input type="checkbox" id="chkAddDownloadOrigin"><span></span>
                                                 <div style="display:inline" data-i18n="optAddDownloadOrigin"></div>
                                             </label>
@@ -456,7 +456,7 @@
                                     </div>
                                    <div class="ttip" data-i18n-tooltip="optAddDownloadSizeTooltip">
                                         <div class="field">
-                                            <label class="checkbox" style="padding-right:100px" for="chkAddDownloadSize">
+                                            <label class="checkbox" style="padding-right:10px" for="chkAddDownloadSize">
                                                 <input type="checkbox" id="chkAddDownloadSize"><span></span>
                                                 <div style="display:inline" data-i18n="optAddDownloadSize"></div>
                                             </label>
@@ -464,9 +464,17 @@
                                     </div>
                                     <div class="ttip" data-i18n-tooltip="optAddDownloadDurationTooltip">
                                         <div class="field">
-                                            <label class="checkbox" for="chkAddDownloadDuration">
+                                            <label class="checkbox" style="padding-right:10px" for="chkAddDownloadDuration">
                                                 <input type="checkbox" id="chkAddDownloadDuration"><span></span>
                                                 <div style="display:inline" data-i18n="optAddDownloadDuration"></div>
+                                            </label>
+                                        </div>
+                                    </div>
+                                    <div class="ttip" data-i18n-tooltip="optAddDownloadIndexTooltip">
+                                        <div class="field">
+                                            <label class="checkbox" for="chkAddDownloadIndex">
+                                                <input type="checkbox" id="chkAddDownloadIndex"><span></span>
+                                                <div style="display:inline" data-i18n="optAddDownloadIndex"></div>
                                             </label>
                                         </div>
                                     </div>

--- a/js/common.js
+++ b/js/common.js
@@ -47,6 +47,7 @@ var factorySettings = {
     addDownloadOrigin : false,
     addDownloadSize : false,
     addDownloadDuration : false,
+    addDownloadIndex : false,
     useSeparateTabOrWindowForUnloadableUrlsEnabled: false,
     useSeparateTabOrWindowForUnloadableUrls: 'window',
     captionLocation : 'below',
@@ -135,6 +136,7 @@ function loadOptions() {
     options.addDownloadOrigin = options.hasOwnProperty('addDownloadOrigin') ? options.addDownloadOrigin : factorySettings.addDownloadOrigin;
     options.addDownloadSize = options.hasOwnProperty('addDownloadSize') ? options.addDownloadSize : factorySettings.addDownloadSize;
     options.addDownloadDuration = options.hasOwnProperty('addDownloadDuration') ? options.addDownloadDuration : factorySettings.addDownloadDuration;
+    options.addDownloadIndex = options.hasOwnProperty('addDownloadIndex') ? options.addDownloadIndex : factorySettings.addDownloadIndex;
     options.useSeparateTabOrWindowForUnloadableUrlsEnabled = options.hasOwnProperty('useSeparateTabOrWindowForUnloadableUrlsEnabled') ? options.useSeparateTabOrWindowForUnloadableUrlsEnabled : factorySettings.useSeparateTabOrWindowForUnloadableUrlsEnabled;
     options.useSeparateTabOrWindowForUnloadableUrls = options.hasOwnProperty('useSeparateTabOrWindowForUnloadableUrls') ? options.useSeparateTabOrWindowForUnloadableUrls : factorySettings.useSeparateTabOrWindowForUnloadableUrls;
 

--- a/js/hoverzoom.js
+++ b/js/hoverzoom.js
@@ -3250,6 +3250,17 @@ var hoverZoom = {
                 let size = '[' + img.naturalWidth + 'x' + img.naturalHeight + ']';
                 filename = size + filename;
             }
+            if (options.addDownloadIndex) {
+                let gallery = hz.currentLink.data().hoverZoomGallerySrc;
+                let index = hz.currentLink.data().hoverZoomGalleryIndex;
+                if (gallery) {
+                    index++;
+                    let indexLen = index.toString().length;
+                    let galleryLen = gallery.length.toString().length
+                    let galleryIndex = `[${index.toString().padStart(galleryLen,'0')}-${gallery.length}]`;
+                    filename = galleryIndex + filename;
+                }
+            }
             if (options.addDownloadOrigin) {
                 // prefix with origin
                 let origin = '[' + getOrigin() + ']';

--- a/js/options.js
+++ b/js/options.js
@@ -139,8 +139,9 @@ function saveOptions() {
     options.downloadFolder = $('#txtDownloadFolder')[0].value;
     options.addDownloadOrigin = $('#chkAddDownloadOrigin')[0].checked;
     options.addDownloadSize = $('#chkAddDownloadSize')[0].checked;
-    options.debug = $('#chkEnableDebug')[0].checked;
     options.addDownloadDuration = $('#chkAddDownloadDuration')[0].checked;
+    options.addDownloadIndex = $('#chkAddDownloadIndex')[0].checked;
+    options.debug = $('#chkEnableDebug')[0].checked;
     options.useSeparateTabOrWindowForUnloadableUrlsEnabled = $('#chkUseSeparateTabOrWindowForUnloadableUrlsEnabled')[0].checked;
     options.useSeparateTabOrWindowForUnloadableUrls = $('#selectUseSeparateTabOrWindowForUnloadableUrls').val();
 
@@ -255,6 +256,7 @@ function restoreOptions(optionsFromFactorySettings) {
     $('#chkAddDownloadOrigin').trigger(options.addDownloadOrigin ? 'gumby.check' : 'gumby.uncheck');
     $('#chkAddDownloadSize').trigger(options.addDownloadSize ? 'gumby.check' : 'gumby.uncheck');
     $('#chkAddDownloadDuration').trigger(options.addDownloadDuration ? 'gumby.check' : 'gumby.uncheck');
+    $('#chkAddDownloadIndex').trigger(options.addDownloadIndex ? 'gumby.check' : 'gumby.uncheck');
     $('#chkUseSeparateTabOrWindowForUnloadableUrlsEnabled').trigger(options.useSeparateTabOrWindowForUnloadableUrlsEnabled ? 'gumby.check' : 'gumby.uncheck');
     $('#selectUseSeparateTabOrWindowForUnloadableUrls').val(options.useSeparateTabOrWindowForUnloadableUrls);
     $('#chkEnableDebug').trigger(options.debug ? 'gumby.check' : 'gumby.uncheck');


### PR DESCRIPTION
For instance, third image out of ten is saved as: [03-10]image.jpg 
This option eases sorting of saved images.
By default, this option is **disabled**.

![image](https://github.com/extesy/hoverzoom/assets/23529041/c6b6ad6f-18dc-4218-8d8d-2ec75e62d273)
