### PR TITLE
New option: add caption to filename when saving

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -536,15 +536,15 @@
         "description": "[options] Placeholder for download folder option"
     },
     "optDownloadFolder": {
-        "message": "Save images & videos to folder: Downloads/",
+        "message": "Save images, videos & audios to folder: Downloads/",
         "description": "[options] Download folder option"
     },
     "optRenameDownloadsTooltip": {
-        "message": "Prefix original names of downloads with origin, size and/or duration for easier management",
+        "message": "Prefix original names of downloads with origin, size, duration and so on for easier management",
         "description": "[options] Tooltip for rename downloads option"
     },
     "optRenameDownloads": {
-        "message": "Rename saved images & videos by adding:",
+        "message": "Rename saved files by adding:",
         "description": "[options] Rename downloads option"
     },
     "optAddDownloadOriginTooltip": {
@@ -578,6 +578,14 @@
     "optAddDownloadIndex": {
         "message": "index",
         "description": "[options] Add download index option"
+    },
+    "optAddDownloadCaptionTooltip": {
+        "message": "Add caption (e.g: Mona Lisa by Leonardo da Vinci)",
+        "description": "[options] Tooltip for add download caption option"
+    },
+    "optAddDownloadCaption": {
+        "message": "caption",
+        "description": "[options] Add download caption option"
     }, 
     "optSectionTroubleshooting": {
         "message": "Troubleshooting",

--- a/html/options.html
+++ b/html/options.html
@@ -472,9 +472,17 @@
                                     </div>
                                     <div class="ttip" data-i18n-tooltip="optAddDownloadIndexTooltip">
                                         <div class="field">
-                                            <label class="checkbox" for="chkAddDownloadIndex">
+                                            <label class="checkbox" style="padding-right:10px" for="chkAddDownloadIndex">
                                                 <input type="checkbox" id="chkAddDownloadIndex"><span></span>
                                                 <div style="display:inline" data-i18n="optAddDownloadIndex"></div>
+                                            </label>
+                                        </div>
+                                    </div>
+                                    <div class="ttip" data-i18n-tooltip="optAddDownloadCaptionTooltip">
+                                        <div class="field">
+                                            <label class="checkbox" for="chkAddDownloadCaption">
+                                                <input type="checkbox" id="chkAddDownloadCaption"><span></span>
+                                                <div style="display:inline" data-i18n="optAddDownloadCaption"></div>
                                             </label>
                                         </div>
                                     </div>

--- a/js/common.js
+++ b/js/common.js
@@ -48,6 +48,7 @@ var factorySettings = {
     addDownloadSize : false,
     addDownloadDuration : false,
     addDownloadIndex : false,
+    addDownloadCaption : false,
     useSeparateTabOrWindowForUnloadableUrlsEnabled: false,
     useSeparateTabOrWindowForUnloadableUrls: 'window',
     captionLocation : 'below',
@@ -137,6 +138,7 @@ function loadOptions() {
     options.addDownloadSize = options.hasOwnProperty('addDownloadSize') ? options.addDownloadSize : factorySettings.addDownloadSize;
     options.addDownloadDuration = options.hasOwnProperty('addDownloadDuration') ? options.addDownloadDuration : factorySettings.addDownloadDuration;
     options.addDownloadIndex = options.hasOwnProperty('addDownloadIndex') ? options.addDownloadIndex : factorySettings.addDownloadIndex;
+    options.addDownloadCaption = options.hasOwnProperty('addDownloadCaption') ? options.addDownloadCaption : factorySettings.addDownloadCaption;
     options.useSeparateTabOrWindowForUnloadableUrlsEnabled = options.hasOwnProperty('useSeparateTabOrWindowForUnloadableUrlsEnabled') ? options.useSeparateTabOrWindowForUnloadableUrlsEnabled : factorySettings.useSeparateTabOrWindowForUnloadableUrlsEnabled;
     options.useSeparateTabOrWindowForUnloadableUrls = options.hasOwnProperty('useSeparateTabOrWindowForUnloadableUrls') ? options.useSeparateTabOrWindowForUnloadableUrls : factorySettings.useSeparateTabOrWindowForUnloadableUrls;
 

--- a/js/hoverzoom.js
+++ b/js/hoverzoom.js
@@ -3245,9 +3245,17 @@ var hoverZoom = {
             let filename = getDownloadFilenameByMedia(downloadMedias.IMG);
             if (!filename) return;
 
+            if (options.addDownloadCaption) {
+                // prefix with caption
+                let caption = getCaption();
+                if (caption) {
+                    caption = '[' + caption + ']';
+                    filename = caption + filename;
+                }
+            }
             if (options.addDownloadSize) {
                 // prefix with size [WxH]
-                let size = '[' + img.naturalWidth + 'x' + img.naturalHeight + ']';
+                let size = '[' + getSizeImage(img) + ']';
                 filename = size + filename;
             }
             if (options.addDownloadIndex) {
@@ -3278,9 +3286,17 @@ var hoverZoom = {
             let filename = getDownloadFilenameByMedia(downloadMedias.VIDEO);
             if (!filename) return;
 
+            if (options.addDownloadCaption) {
+                // prefix with caption
+                let caption = getCaption();
+                if (caption) {
+                    caption = '[' + caption + ']';
+                    filename = caption + filename;
+                }
+            }
             if (options.addDownloadSize) {
                 // prefix with size [WxH]
-                let size = '[' + video.videoWidth + 'x' + video.videoHeight + ']';
+                let size = '[' + getSizeVideo(video) + ']';
                 filename = size + filename;
             }
             if (options.addDownloadDuration) {
@@ -3304,6 +3320,14 @@ var hoverZoom = {
             let filename = getDownloadFilenameByMedia(downloadMedias.AUDIO);
             if (!filename) return;
 
+            if (options.addDownloadCaption) {
+                // prefix with caption
+                let caption = getCaption();
+                if (caption) {
+                    caption = '[' + caption + ']';
+                    filename = caption + filename;
+                }
+            }
             if (options.addDownloadDuration) {
                 // prefix with duration [hh mm ss]
                 let duration = hz.secondsToHms(audio.duration);
@@ -3325,6 +3349,14 @@ var hoverZoom = {
             let filename = getDownloadFilenameByMedia(downloadMedias.SUBTITLES);
             if (!filename) return;
 
+            if (options.addDownloadCaption) {
+                // prefix with caption
+                let caption = getCaption();
+                if (caption) {
+                    caption = '[' + caption + ']';
+                    filename = caption + filename;
+                }
+            }
             if (options.addDownloadOrigin) {
                 // prefix with origin
                 let origin = '[' + getOrigin() + ']';
@@ -3342,9 +3374,17 @@ var hoverZoom = {
             let filename = getDownloadFilenameByMedia(downloadMedias.PLAYLIST);
             if (!filename) return;
 
+            if (options.addDownloadCaption) {
+                // prefix with caption
+                let caption = getCaption();
+                if (caption) {
+                    caption = '[' + caption + ']';
+                    filename = caption + filename;
+                }
+            }
             if (options.addDownloadSize) {
                 // prefix with size [WxH]
-                let size = '[' + video.videoWidth + 'x' + video.videoHeight + ']';
+                let size = '[' + getSizeVideo(video) + ']';
                 filename = size + filename;
             }
             if (options.addDownloadDuration) {
@@ -3427,6 +3467,22 @@ var hoverZoom = {
         // return hostname with forbidden characters replaced by '_'
         function getOrigin() {
             return window.location.hostname.replace(regexForbiddenChars, '_');
+        }
+
+        // return displayed size (W x H)
+        function getSizeVideo(video) {
+            return video.videoWidth + 'x' + video.videoHeight;
+        }
+
+        // return displayed size (W x H)
+        function getSizeImage(img) {
+            return img.naturalWidth + 'x' + img.naturalHeight;
+        }
+
+        // return caption with forbidden characters replaced by '_'
+        function getCaption() {
+            let caption = hz.currentLink.data().hoverZoomCaption || hz.currentLink.data().hoverZoomGalleryCaption || '';
+            return caption.replace(regexForbiddenChars, '_');
         }
 
         function rotateGalleryImg(rot) {

--- a/js/options.js
+++ b/js/options.js
@@ -141,6 +141,7 @@ function saveOptions() {
     options.addDownloadSize = $('#chkAddDownloadSize')[0].checked;
     options.addDownloadDuration = $('#chkAddDownloadDuration')[0].checked;
     options.addDownloadIndex = $('#chkAddDownloadIndex')[0].checked;
+    options.addDownloadCaption = $('#chkAddDownloadCaption')[0].checked;
     options.debug = $('#chkEnableDebug')[0].checked;
     options.useSeparateTabOrWindowForUnloadableUrlsEnabled = $('#chkUseSeparateTabOrWindowForUnloadableUrlsEnabled')[0].checked;
     options.useSeparateTabOrWindowForUnloadableUrls = $('#selectUseSeparateTabOrWindowForUnloadableUrls').val();
@@ -257,6 +258,7 @@ function restoreOptions(optionsFromFactorySettings) {
     $('#chkAddDownloadSize').trigger(options.addDownloadSize ? 'gumby.check' : 'gumby.uncheck');
     $('#chkAddDownloadDuration').trigger(options.addDownloadDuration ? 'gumby.check' : 'gumby.uncheck');
     $('#chkAddDownloadIndex').trigger(options.addDownloadIndex ? 'gumby.check' : 'gumby.uncheck');
+    $('#chkAddDownloadCaption').trigger(options.addDownloadCaption ? 'gumby.check' : 'gumby.uncheck');
     $('#chkUseSeparateTabOrWindowForUnloadableUrlsEnabled').trigger(options.useSeparateTabOrWindowForUnloadableUrlsEnabled ? 'gumby.check' : 'gumby.uncheck');
     $('#selectUseSeparateTabOrWindowForUnloadableUrls').val(options.useSeparateTabOrWindowForUnloadableUrls);
     $('#chkEnableDebug').trigger(options.debug ? 'gumby.check' : 'gumby.uncheck');


### PR DESCRIPTION
For instance, an image of Mona Lisa is saved as: `[Mona Lisa by Leonardo da Vinci]image03.jpg`
By default, this option is **disabled**.

This new option is available in Advanced options:

![image](https://github.com/extesy/hoverzoom/assets/23529041/4ca304bb-ded6-4487-a7c4-d26014b2e28c)
