### PR TITLE
New feature : replace original filename when saving

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -587,6 +587,18 @@
         "message": "caption",
         "description": "[options] Add download caption option"
     }, 
+  "optDownloadReplaceOriginalFilenameTooltip": {
+    "message": "Replace original filename or remove it if no value supplied (extension is preserved)",
+    "description": "[options] Tooltip for replace original filename when downloading option"
+  },
+  "optDownloadReplaceOriginalFilenamePlaceholder": {
+    "message": "Example: fullsize_image",
+    "description": "[options] Placeholder for download folder option"
+  },
+  "optDownloadReplaceOriginalFilename": {
+    "message": "On save, replace original filename by:",
+    "description": "[options] Replace original filename when downloading option"
+  },
     "optSectionTroubleshooting": {
         "message": "Troubleshooting",
         "description": "[options] Page section for troubleshooting"

--- a/html/options.html
+++ b/html/options.html
@@ -487,6 +487,15 @@
                                         </div>
                                     </div>
                                 </div>
+                                <div class="ttip" data-i18n-tooltip="optDownloadReplaceOriginalFilenameTooltip">
+                                    <li class="append field">
+                                        <label class="checkbox inline" style="padding-right:10px" for="chkDownloadReplaceOriginalFilename">
+                                            <input type="checkbox" id="chkDownloadReplaceOriginalFilename"><span></span>
+                                            <div style="display:inline" data-i18n="optDownloadReplaceOriginalFilename"></div>
+                                        </label>
+                                        <input class="normal text input" type="text" id="txtDownloadReplaceOriginalFilename" data-i18n-placeholder="optDownloadReplaceOriginalFilenamePlaceholder">
+                                    </li>
+                                </div>
                             </ul>
                         </fieldset>
                         <fieldset>

--- a/js/common.js
+++ b/js/common.js
@@ -49,6 +49,8 @@ var factorySettings = {
     addDownloadDuration : false,
     addDownloadIndex : false,
     addDownloadCaption : false,
+    replaceOriginalFilename : false,
+    downloadFilename : '',
     useSeparateTabOrWindowForUnloadableUrlsEnabled: false,
     useSeparateTabOrWindowForUnloadableUrls: 'window',
     captionLocation : 'below',
@@ -139,6 +141,8 @@ function loadOptions() {
     options.addDownloadDuration = options.hasOwnProperty('addDownloadDuration') ? options.addDownloadDuration : factorySettings.addDownloadDuration;
     options.addDownloadIndex = options.hasOwnProperty('addDownloadIndex') ? options.addDownloadIndex : factorySettings.addDownloadIndex;
     options.addDownloadCaption = options.hasOwnProperty('addDownloadCaption') ? options.addDownloadCaption : factorySettings.addDownloadCaption;
+    options.replaceOriginalFilename = options.hasOwnProperty('replaceOriginalFilename') ? options.replaceOriginalFilename : factorySettings.replaceOriginalFilename;
+    options.downloadFilename = options.hasOwnProperty('downloadFilename') ? options.downloadFilename : factorySettings.downloadFilename;
     options.useSeparateTabOrWindowForUnloadableUrlsEnabled = options.hasOwnProperty('useSeparateTabOrWindowForUnloadableUrlsEnabled') ? options.useSeparateTabOrWindowForUnloadableUrlsEnabled : factorySettings.useSeparateTabOrWindowForUnloadableUrlsEnabled;
     options.useSeparateTabOrWindowForUnloadableUrls = options.hasOwnProperty('useSeparateTabOrWindowForUnloadableUrls') ? options.useSeparateTabOrWindowForUnloadableUrls : factorySettings.useSeparateTabOrWindowForUnloadableUrls;
 

--- a/js/options.js
+++ b/js/options.js
@@ -142,6 +142,8 @@ function saveOptions() {
     options.addDownloadDuration = $('#chkAddDownloadDuration')[0].checked;
     options.addDownloadIndex = $('#chkAddDownloadIndex')[0].checked;
     options.addDownloadCaption = $('#chkAddDownloadCaption')[0].checked;
+    options.replaceOriginalFilename = $('#chkDownloadReplaceOriginalFilename')[0].checked;
+    options.downloadFilename = $('#txtDownloadReplaceOriginalFilename')[0].value;
     options.debug = $('#chkEnableDebug')[0].checked;
     options.useSeparateTabOrWindowForUnloadableUrlsEnabled = $('#chkUseSeparateTabOrWindowForUnloadableUrlsEnabled')[0].checked;
     options.useSeparateTabOrWindowForUnloadableUrls = $('#selectUseSeparateTabOrWindowForUnloadableUrls').val();
@@ -259,6 +261,8 @@ function restoreOptions(optionsFromFactorySettings) {
     $('#chkAddDownloadDuration').trigger(options.addDownloadDuration ? 'gumby.check' : 'gumby.uncheck');
     $('#chkAddDownloadIndex').trigger(options.addDownloadIndex ? 'gumby.check' : 'gumby.uncheck');
     $('#chkAddDownloadCaption').trigger(options.addDownloadCaption ? 'gumby.check' : 'gumby.uncheck');
+    $('#chkDownloadReplaceOriginalFilename').trigger(options.replaceOriginalFilename ? 'gumby.check' : 'gumby.uncheck');
+    $('#txtDownloadReplaceOriginalFilename').val(options.downloadFilename);
     $('#chkUseSeparateTabOrWindowForUnloadableUrlsEnabled').trigger(options.useSeparateTabOrWindowForUnloadableUrlsEnabled ? 'gumby.check' : 'gumby.uncheck');
     $('#selectUseSeparateTabOrWindowForUnloadableUrls').val(options.useSeparateTabOrWindowForUnloadableUrls);
     $('#chkEnableDebug').trigger(options.debug ? 'gumby.check' : 'gumby.uncheck');
@@ -453,11 +457,29 @@ function downloadFolderOnChange(val) {
     return this.value;
 }
 
+// validate user input
+function replaceOriginalFilenameOnChange(val) {
+    let value = (typeof val == 'string' ? val : this.value);
+    value = value.trim();
+    // remove Windows Explorer forbidden characters for file name -> : * ? " < > | /
+    value = value.replace(/[!*:?"<>|\/\\]/g, '');
+    this.value = value;
+    return this.value;
+}
+
 function updateDivAmbilight() {
     if ($('#chkAmbilightEnabled')[0].checked) {
         $('#divAmbilight').removeClass('disabled');
     } else {
         $('#divAmbilight').addClass('disabled');
+    }
+}
+
+function updateDownloadReplaceOriginalFilename() {
+    if ($('#chkDownloadReplaceOriginalFilename')[0].checked) {
+        $('#txtDownloadReplaceOriginalFilename').removeClass('disabled');
+    } else {
+        $('#txtDownloadReplaceOriginalFilename').addClass('disabled');
     }
 }
 
@@ -658,6 +680,8 @@ $(function () {
     $('#btnAddExcludedSite').click(btnAddExcludedSiteOnClick);
     $('#btnRemoveExcludedSite').click(btnRemoveExcludedSiteOnClick);
     $('#txtDownloadFolder').change(downloadFolderOnChange);
+    $('#chkDownloadReplaceOriginalFilename').parent().on('gumby.onChange', updateDownloadReplaceOriginalFilename);
+    $('#txtDownloadReplaceOriginalFilename').change(replaceOriginalFilenameOnChange);
     $('#chkUseSeparateTabOrWindowForUnloadableUrlsEnabled').parent().on('gumby.onChange', updateUseSeparateTabOrWindowForUnloadableUrls);
     $('#chkHideMouseCursor').parent().on('gumby.onChange', updateDivHideMouseCursor);
     $('#chkDarkMode').parent().on('gumby.onChange', updateDarkMode);


### PR DESCRIPTION
Original filenames might be meaningless (e.g: 125487_asdfg.jpg)
This option allows replacing them by something more relevant.
Extensions are preserved.
If option is enabled and no replacement is given then original filename is removed.
By default, this option is **disabled**.

This new option is available in Advanced options:

![image](https://github.com/user-attachments/assets/e8271ff3-dbef-45f3-997a-59afbca63f30)


