### PR TITLE
Fix: LinkedIn profile pictures with 'hiring' or 'open to work' tags not zooming correctly

### DIFF
--- a/plugins/linkedin.js
+++ b/plugins/linkedin.js
@@ -158,8 +158,9 @@ hoverZoomPlugins.push({
             try {
                 let j = JSON.parse(response);
                 let rootUrl = j.miniProfile.picture["com.linkedin.common.VectorImage"].rootUrl;
-                let nbPictures = j.miniProfile.picture["com.linkedin.common.VectorImage"].artifacts.length;
-                let largestPicture = j.miniProfile.picture["com.linkedin.common.VectorImage"].artifacts[nbPictures - 1].fileIdentifyingUrlPathSegment;
+                let artifacts = j.miniProfile.picture["com.linkedin.common.VectorImage"].artifacts;
+                artifacts.sort((a, b) => b.width - a.width);
+                let largestPicture = artifacts[0].fileIdentifyingUrlPathSegment;
                 let fullsizeUrl = rootUrl + largestPicture;
                 let caption = j.firstName + " " + j.lastName + " - " + j.headline;
 


### PR DESCRIPTION
> This PR fixes an issue with LinkedIn profile pictures containing tags like 'hiring' or 'open to work' that were not zooming correctly in the HoverZoom extension.


Previously, the code assumed that the 4th image in the LinkedIn API response was always the largest one. However, in cases where profile tags such as 'hiring' or 'open to work' are present, the 4th image is actually the smallest. This PR updates the image selection logic to handle such cases, ensuring that the correct (largest) image is used for zooming, regardless of the presence of these tags.