### PR TITLE
Fix: Function prepareFromDocument() breaking on Firefox

### DIFF
--- a/js/hoverzoom.js
+++ b/js/hoverzoom.js
@@ -3866,20 +3866,18 @@ var hoverZoom = {
     prepareFromDocument:function (link, url, getSrc, isAsync = false) {
         url = url.replace('http:', location.protocol);
         chrome.runtime.sendMessage({action:'ajaxRequest', url: url, method: 'GET'}, function(data) {
-            var doc = document.implementation.createHTMLDocument();
-            doc.open();
-            doc.write(data);
-            doc.close();
-            var httpRefresh = doc.querySelector('meta[http-equiv="refresh"][content]');
+            let doc = document.implementation.createHTMLDocument();
+            doc.body.innerHTML = data;
+            let httpRefresh = doc.querySelector('meta[http-equiv="refresh"][content]');
             if (httpRefresh) {
-                var redirUrl = httpRefresh.content.substr(httpRefresh.content.toLowerCase().indexOf('url=') + 4);
+                let redirUrl = httpRefresh.content.substr(httpRefresh.content.toLowerCase().indexOf('url=') + 4);
                 if (redirUrl) {
                     redirUrl = redirUrl.replace('http:', location.protocol);
                     hoverZoom.prepareFromDocument(link, redirUrl, getSrc, isAsync);
                 }
             }
 
-            var handleSrc = function (src) {
+            let handleSrc = function (src) {
                 if (src)
                     hoverZoom.prepareLink(link, src);
             };
@@ -3887,7 +3885,7 @@ var hoverZoom = {
             if (isAsync) {
                 getSrc(doc, handleSrc);
             } else {
-                var src = getSrc(doc);
+                let src = getSrc(doc);
                 handleSrc(src);
             }
         });

--- a/js/hoverzoom.js
+++ b/js/hoverzoom.js
@@ -3868,7 +3868,7 @@ var hoverZoom = {
         chrome.runtime.sendMessage({action:'ajaxRequest', url: url, method: 'GET'}, function(data) {
             let doc = document.implementation.createHTMLDocument();
             doc.body.innerHTML = data;
-            let httpRefresh = doc.querySelector('meta[http-equiv="refresh"][content]');
+            const httpRefresh = doc.querySelector('meta[http-equiv="refresh"][content]');
             if (httpRefresh) {
                 let redirUrl = httpRefresh.content.substr(httpRefresh.content.toLowerCase().indexOf('url=') + 4);
                 if (redirUrl) {
@@ -3877,7 +3877,7 @@ var hoverZoom = {
                 }
             }
 
-            let handleSrc = function (src) {
+            const handleSrc = function (src) {
                 if (src)
                     hoverZoom.prepareLink(link, src);
             };


### PR DESCRIPTION
In hoverzoom.js, changes:
```js
doc.open(); 
doc.write(data);
doc.close();
```
to 
```js
doc.body.innerHTML = data;
```

- This fixes it giving the following error on Firefox: `"SecurityError: The operation is insecure."`
- Also updated variable scopes to match the style guide.

This will fix some plugins on Firefox that rely on prepareFromDocument() to function. Issue #429 is fixed with this, and there might be more. I tested it on Chrome and Firefox, and it worked for me.