### PR TITLE
Fix: "Save image" Action Key does not work

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -95,6 +95,15 @@ function onMessage(message, sender, callback) {
             return true;
         case 'downloadFile':
             cLog('downloadFile: ' + message);
+            // Workaround for permissions.request not returning a promise in Firefox 
+            // First checks if permissions are availble. If not, requests them.
+            // Not as clean or effecient.
+            chrome.permissions.contains({permissions: ['tabs']}).then(function (granted) {
+                cLog('downloadFile granted: ' + granted);
+                if (granted) {
+                    downloadFile(message.url, message.filename, message.conflictAction, callback);
+                }
+            }),
             chrome.permissions.request({permissions: ['downloads']}, function (granted) {
                 cLog('downloadFile granted: ' + granted);
                 if (granted) {

--- a/js/background.js
+++ b/js/background.js
@@ -94,9 +94,9 @@ function onMessage(message, sender, callback) {
             * Not as clean or effecient as just using 'permissions.request'.
             */
             cLog('downloadFileBlob: ' + message);
-            chrome.permissions.contains({permissions: ['downloads']}, (granted) => {
-                cLog('downloadFile contains: ' + granted);
-                if (granted) {
+            chrome.permissions.contains({permissions: ['downloads']}, (contained) => {
+                cLog('downloadFile contains: ' + contained);
+                if (contained) {
                     ajaxRequest({method:'GET', response:'DOWNLOAD', url:message.url, filename:message.filename, conflictAction:message.conflictAction, headers:message.headers}, callback);
                 } else {
                     chrome.permissions.request({permissions: ['downloads']}, (granted) => {
@@ -115,9 +115,9 @@ function onMessage(message, sender, callback) {
             * First checks if permissions are availble. If true, downloads file. If not, requests them.
             * Not as clean or effecient as just using 'permissions.request'.
             */
-            chrome.permissions.contains({permissions: ['downloads']}, (granted) => {
-                cLog('downloadFile contains: ' + granted);
-                if (granted) {
+            chrome.permissions.contains({permissions: ['downloads']}, (contained) => {
+                cLog('downloadFile contains: ' + contained);
+                if (contained) {
                     downloadFile(message.url, message.filename, message.conflictAction, callback);
                 } else {
                     chrome.permissions.request({permissions: ['downloads']}, (granted) => {

--- a/js/background.js
+++ b/js/background.js
@@ -98,12 +98,13 @@ function onMessage(message, sender, callback) {
                 cLog('downloadFile contains: ' + granted);
                 if (granted) {
                     ajaxRequest({method:'GET', response:'DOWNLOAD', url:message.url, filename:message.filename, conflictAction:message.conflictAction, headers:message.headers}, callback);
-                }
-            }),
-            chrome.permissions.request({permissions: ['downloads']}, (granted) => {
-                cLog('downloadFile granted: ' + granted);
-                if (granted) {
-                    ajaxRequest({method:'GET', response:'DOWNLOAD', url:message.url, filename:message.filename, conflictAction:message.conflictAction, headers:message.headers}, callback);
+                } else {
+                    chrome.permissions.request({permissions: ['downloads']}, (granted) => {
+                        cLog('downloadFile granted: ' + granted);
+                        if (granted) {
+                            ajaxRequest({method:'GET', response:'DOWNLOAD', url:message.url, filename:message.filename, conflictAction:message.conflictAction, headers:message.headers}, callback);
+                        }
+                    })
                 }
             });
             return true;
@@ -118,12 +119,13 @@ function onMessage(message, sender, callback) {
                 cLog('downloadFile contains: ' + granted);
                 if (granted) {
                     downloadFile(message.url, message.filename, message.conflictAction, callback);
-                }
-            }),
-            chrome.permissions.request({permissions: ['downloads']}, (granted) => {
-                cLog('downloadFile granted: ' + granted);
-                if (granted) {
-                    downloadFile(message.url, message.filename, message.conflictAction, callback);
+                } else {
+                    chrome.permissions.request({permissions: ['downloads']}, (granted) => {
+                        cLog('downloadFile granted: ' + granted);
+                        if (granted) {
+                            downloadFile(message.url, message.filename, message.conflictAction, callback);
+                        }
+                    })
                 }
             });
             return true;


### PR DESCRIPTION
Fix for #1387
Changes:
```js
chrome.permissions.request({permissions: ['downloads']}, function (granted) {
    cLog('downloadFile granted: ' + granted);
    if (granted) {
        ...
    }
});
```
to
```js
chrome.permissions.contains({permissions: ['downloads']}, (contained) => {
    cLog('downloadFile contains: ' + contained);
    if (contained) {
        ...
    } else {
        chrome.permissions.request({permissions: ['downloads']}, (granted) => {
            cLog('downloadFile granted: ' + granted);
            if (granted) {
                ...
            }
        })
    }
});
```

This fixes images not downloading on Firefox, and still allows chrome to request permissions via a prompt. It is not an ideal fix, but until this bug is resolved on Firefox's end, this is the best fix I found.