### PR TITLE
Fix: Hovered images flicker on Fur Affinity

### DIFF
--- a/plugins/furaffinity.js
+++ b/plugins/furaffinity.js
@@ -9,7 +9,8 @@ hoverZoomPlugins.push({
 		}).addClass('hoverZoomMouseover').one('mouseover', function() {
             hoverZoom.prepareFromDocument($(this), this.href, function(doc) {
                 var img = doc.querySelector('img[data-fullview-src]');
-                return img ? img.dataset.fullviewSrc : null;
+                const fullImg = img ? 'http:' + img.dataset.fullviewSrc : null;
+                return fullImg
             });
         });
         callback($(res), this.name);

--- a/plugins/furaffinity.js
+++ b/plugins/furaffinity.js
@@ -3,12 +3,12 @@ hoverZoomPlugins.push({
     name:'FurAffinity',
     version:'0.2',
     prepareImgLinks:function (callback) {
-        var res = [];
+        let res = [];
         $('a[href*="/view/"]:not(.hoverZoomMouseover)').filter(function() {
 			return this.href.match(/\/view\/\d+\/$/);
 		}).addClass('hoverZoomMouseover').one('mouseover', function() {
             hoverZoom.prepareFromDocument($(this), this.href, function(doc) {
-                var img = doc.querySelector('img[data-fullview-src]');
+                const img = doc.querySelector('img[data-fullview-src]');
                 const fullImg = img ? 'http:' + img.dataset.fullviewSrc : null;
                 return fullImg
             });

--- a/plugins/furaffinity.js
+++ b/plugins/furaffinity.js
@@ -9,8 +9,7 @@ hoverZoomPlugins.push({
 		}).addClass('hoverZoomMouseover').one('mouseover', function() {
             hoverZoom.prepareFromDocument($(this), this.href, function(doc) {
                 const img = doc.querySelector('img[data-fullview-src]');
-                const fullImg = img ? 'http:' + img.dataset.fullviewSrc : null;
-                return fullImg
+                return img ? 'http:' + img.dataset.fullviewSrc : null;
             });
         });
         callback($(res), this.name);

--- a/plugins/furaffinity.js
+++ b/plugins/furaffinity.js
@@ -9,7 +9,7 @@ hoverZoomPlugins.push({
 		}).addClass('hoverZoomMouseover').one('mouseover', function() {
             hoverZoom.prepareFromDocument($(this), this.href, function(doc) {
                 const img = doc.querySelector('img[data-fullview-src]');
-                return img ? 'http:' + img.dataset.fullviewSrc : null;
+                return img ? 'https:' + img.dataset.fullviewSrc : null;
             });
         });
         callback($(res), this.name);


### PR DESCRIPTION
I fixed images flickering when you move your mouse around while hovering over one.
- Made prepareFromDocument callback function return a full url
```js
    return img ? img.dataset.fullviewSrc : null;
```
to
```js
    return img ? 'https:' + img.dataset.fullviewSrc : null;
```
- Updated variable scopes