### PR TITLE
Add 'Automatically lock images' function

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -323,6 +323,14 @@
         "message": "Center images as opposed to having them follow the cursor",
         "description": "[options] Tooltip for center images in the middle of the page option"
     },
+    "optAutoLockImages": {
+        "message": "Automatically lock images",
+        "description": "[options] Automatically lock images option"
+    },
+    "optAutoLockImagesTooltip": {
+        "message": "Automatically lock images when activating Hover Zoom+",
+        "description": "[options] Tooltip for automatically lock images option"
+    },
     "optFrameBackgroundColor": {
         "message": "Frame background color:",
         "description": "[options] Frame background color option"

--- a/html/options.html
+++ b/html/options.html
@@ -162,6 +162,14 @@
                                         </label>
                                     </li>
                                 </div>
+                                <div class="ttip" data-i18n-tooltip="optAutoLockImagesTooltip">
+                                    <li class="field">
+                                        <label class="checkbox" for="chkAutoLockImages">
+                                            <input type="checkbox" id="chkAutoLockImages"><span></span>
+                                            <div style="display:inline" data-i18n="optAutoLockImages"></div>
+                                        </label>
+                                    </li>
+                                </div>
                                 <div id="divFrame" style="display:flex">
                                     <div class="ttip" data-i18n-tooltip="optFrameBackgroundColorTooltip">
                                         <li class="field">

--- a/js/common.js
+++ b/js/common.js
@@ -34,7 +34,7 @@ var factorySettings = {
     ambilightBackgroundOpacity : 0.9,
     disabledPlugins : [],
     centerImages : false,
-    autoLockImages  : false,
+    autoLockImages : false,
     frameBackgroundColor: "#ffffff",
     frameThickness: 4,
     displayImageLoader: false,

--- a/js/common.js
+++ b/js/common.js
@@ -34,6 +34,7 @@ var factorySettings = {
     ambilightBackgroundOpacity : 0.9,
     disabledPlugins : [],
     centerImages : false,
+    autoLockImages  : false,
     frameBackgroundColor: "#ffffff",
     frameThickness: 4,
     displayImageLoader: false,

--- a/js/common.js
+++ b/js/common.js
@@ -126,6 +126,7 @@ function loadOptions() {
     options.ambilightBackgroundOpacity = options.hasOwnProperty('ambilightBackgroundOpacity') ? options.ambilightBackgroundOpacity : factorySettings.ambilightBackgroundOpacity;
     options.disabledPlugins = options.hasOwnProperty('disabledPlugins') ? options.disabledPlugins : factorySettings.disabledPlugins;
     options.centerImages = options.hasOwnProperty('centerImages') ? options.centerImages : factorySettings.centerImages;
+    options.autoLockImages = options.hasOwnProperty('autoLockImages') ? options.autoLockImages : factorySettings.autoLockImages;
     options.frameBackgroundColor = options.hasOwnProperty('frameBackgroundColor') ? options.frameBackgroundColor : factorySettings.frameBackgroundColor;
     options.frameThickness = options.hasOwnProperty('frameThickness') ? options.frameThickness : factorySettings.frameThickness;
     options.displayImageLoader = options.hasOwnProperty('displayImageLoader') ? options.displayImageLoader : factorySettings.displayImageLoader;

--- a/js/hoverzoom.js
+++ b/js/hoverzoom.js
@@ -1577,6 +1577,11 @@ var hoverZoom = {
 
         function displayFullSizeImage() {
             cLog('displayFullSizeImage');
+
+            // if autoLock activate option is checked
+            if (options.autoLockImages)
+                viewerLocked = true;
+
             // check focus
             let focus = document.hasFocus();
 

--- a/js/hoverzoom.js
+++ b/js/hoverzoom.js
@@ -1578,7 +1578,7 @@ var hoverZoom = {
         function displayFullSizeImage() {
             cLog('displayFullSizeImage');
 
-            // if autoLock activate option is checked
+            // if autoLockImages option is checked
             if (options.autoLockImages)
                 viewerLocked = true;
 

--- a/js/options.js
+++ b/js/options.js
@@ -103,6 +103,7 @@ function saveOptions() {
     options.ambilightHaloSize = $('#txtAmbilightHaloSize')[0].value / 100;
     options.ambilightBackgroundOpacity = $('#txtAmbilightBackgroundOpacity')[0].value / 100;
     options.centerImages = $('#chkCenterImages')[0].checked;
+    options.autoLockImages = $('#chkAutoLockImages')[0].checked;
     options.frameBackgroundColor = $('#pickerFrameBackgroundColor')[0].value;
     options.frameThickness = $('#txtFrameThickness')[0].value;
 
@@ -200,6 +201,7 @@ function restoreOptions(optionsFromFactorySettings) {
     $('#rngAmbilightBackgroundOpacity').val(parseInt(options.ambilightBackgroundOpacity * 100));
     $('#txtAmbilightBackgroundOpacity').val(parseInt(options.ambilightBackgroundOpacity * 100));
     $('#chkCenterImages').trigger(options.centerImages ? 'gumby.check' : 'gumby.uncheck');
+    $('#chkAutoLockImages').trigger(options.autoLockImages ? 'gumby.check' : 'gumby.uncheck');
     $('#pickerFrameBackgroundColor').val(options.frameBackgroundColor);
     $('#rngFrameThickness').val(parseInt(options.frameThickness));
     $('#txtFrameThickness').val(parseInt(options.frameThickness));


### PR DESCRIPTION
Requested option from issue #1216

- Locks image whenever Hover Zoom activates. Added option for it in the options page. Only has English name and tooltip.

- Tested in Firefox and Chrome