### PR TITLE
Fix: Fullzoom button not filling window

### DIFF
--- a/js/hoverzoom.js
+++ b/js/hoverzoom.js
@@ -486,11 +486,11 @@ var hoverZoom = {
 
                 // width adjustment
                 const fullZoom = options.mouseUnderlap ||  viewerLocked;
-                const fullZoomKey = fullZoomKeyDown
+                const fullZoomKey = fullZoomKeyDown;
                 if (viewerLocked) {
                     imgFullSize.width(srcDetails.naturalWidth * zoomFactor);
                 } else if (fullZoomKey) {
-                    //naturalWidth replaced with wndWidth to make image fill window
+                    // naturalWidth replaced with wndWidth to make image fill window
                     imgFullSize.width(Math.min(wndWidth, wndWidth - padding - 2 * scrollBarWidth)); 
                 } else if (fullZoom) {
                     imgFullSize.width(Math.min(srcDetails.naturalWidth * zoomFactor, wndWidth - padding - 2 * scrollBarWidth));

--- a/js/hoverzoom.js
+++ b/js/hoverzoom.js
@@ -490,7 +490,7 @@ var hoverZoom = {
                 if (viewerLocked) {
                     imgFullSize.width(srcDetails.naturalWidth * zoomFactor);
                 } else if (fullZoomKey) {
-                    //naturalWidth replaced with wndWidth to make image fit window size
+                    //naturalWidth replaced with wndWidth to make image fill window
                     imgFullSize.width(Math.min(wndWidth, wndWidth - padding - 2 * scrollBarWidth)); 
                 } else if (fullZoom) {
                     imgFullSize.width(Math.min(srcDetails.naturalWidth * zoomFactor, wndWidth - padding - 2 * scrollBarWidth));

--- a/js/hoverzoom.js
+++ b/js/hoverzoom.js
@@ -485,9 +485,13 @@ var hoverZoom = {
                 }
 
                 // width adjustment
-                var fullZoom = options.mouseUnderlap || fullZoomKeyDown || viewerLocked;
+                const fullZoom = options.mouseUnderlap ||  viewerLocked;
+                const fullZoomKey = fullZoomKeyDown
                 if (viewerLocked) {
                     imgFullSize.width(srcDetails.naturalWidth * zoomFactor);
+                } else if (fullZoomKey) {
+                    //Replace zoomFactor by a large number to fill viewer screen
+                    imgFullSize.width(Math.min(srcDetails.naturalWidth * 500, wndWidth - padding - 2 * scrollBarWidth)); 
                 } else if (fullZoom) {
                     imgFullSize.width(Math.min(srcDetails.naturalWidth * zoomFactor, wndWidth - padding - 2 * scrollBarWidth));
                 } else if (displayOnRight) {

--- a/js/hoverzoom.js
+++ b/js/hoverzoom.js
@@ -2349,7 +2349,7 @@ var hoverZoom = {
             // for instance, on TripAdvisor:
             // img's src placeholder is replaced by real img url stored in data-lazyurl as user scrolls down
             $(document).on('scroll mousewheel', function() {
-                let scrollTop = window.pageYOffset || document.documentElement.scrollTop; // Credits: "https://github.com/qeremy/so/blob/master/so.dom.js#L426"
+                let scrollTop = window.scrollY || document.documentElement.scrollTop; // Credits: "https://github.com/qeremy/so/blob/master/so.dom.js#L426"
                 if (scrollTop < lastScrollTop) {
                     lastScrollTop = scrollTop < 0 ? 0 : scrollTop; // For Mobile or negative scrolling
                 } else if (scrollTop > lastScrollTop + deltaMin) {

--- a/js/hoverzoom.js
+++ b/js/hoverzoom.js
@@ -490,8 +490,8 @@ var hoverZoom = {
                 if (viewerLocked) {
                     imgFullSize.width(srcDetails.naturalWidth * zoomFactor);
                 } else if (fullZoomKey) {
-                    //Replace zoomFactor by a large number to fill viewer screen
-                    imgFullSize.width(Math.min(srcDetails.naturalWidth * 500, wndWidth - padding - 2 * scrollBarWidth)); 
+                    //naturalWidth replaced with wndWidth to make image fit window size
+                    imgFullSize.width(Math.min(wndWidth, wndWidth - padding - 2 * scrollBarWidth)); 
                 } else if (fullZoom) {
                     imgFullSize.width(Math.min(srcDetails.naturalWidth * zoomFactor, wndWidth - padding - 2 * scrollBarWidth));
                 } else if (displayOnRight) {


### PR DESCRIPTION
From issue #570

- When pressing the 'Full Zoom' button, the image will expand to window's size + padding.
- Fullzoom might look better if the image could stretch to completely to bottom of window, but this implementation works.
- Tested on Firefox and Chrome