### PR TITLE
Fix: GitHub not loading private user images

### DIFF
--- a/plugins/github.js
+++ b/plugins/github.js
@@ -11,6 +11,12 @@ hoverZoomPlugins.push({
             img.data('hoverZoomCaption', [img.attr('alt')]);
             res.push(img);
         });
+
+        $('img[src*="private-user-images"]').each(function () {
+            var img = $(this);
+            img.data('hoverZoomSrc', [img.attr('src')]);
+            res.push(img);
+        });
         
         hoverZoom.urlReplace(res,
             'a[href*="/blob/"]',
@@ -23,6 +29,7 @@ hoverZoomPlugins.push({
             /(.*)\?(.*)/,
             '$1'
         );
+        
         
         callback($(res), this.name);
     }

--- a/plugins/github.js
+++ b/plugins/github.js
@@ -30,7 +30,6 @@ hoverZoomPlugins.push({
             '$1'
         );
         
-        
         callback($(res), this.name);
     }
 });

--- a/plugins/github.js
+++ b/plugins/github.js
@@ -3,17 +3,17 @@ hoverZoomPlugins.push({
     name:'GitHub',
     version:'0.3',
     prepareImgLinks:function (callback) {
-        var res = [];
+        const res = [];
         
         $('a > img[data-canonical-src]').each(function () {
-            var img = $(this);
+            let img = $(this);
             img.data('hoverZoomSrc', [img.attr('data-canonical-src')]);
             img.data('hoverZoomCaption', [img.attr('alt')]);
             res.push(img);
         });
 
         $('img[src*="private-user-images"]').each(function () {
-            var img = $(this);
+            let img = $(this);
             img.data('hoverZoomSrc', [img.attr('src')]);
             res.push(img);
         });


### PR DESCRIPTION
Images on github with a src containing "private-user-images" wasn't loading before. This fixes that. I discovered the issue when looking at issues on the hz+ repository.