### PR TITLE
Fix: Zoomed images's horizontal position wrong on Fur Affinity on 2k monitors

### DIFF
--- a/js/hoverzoom.js
+++ b/js/hoverzoom.js
@@ -485,7 +485,7 @@ var hoverZoom = {
                 }
 
                 // width adjustment
-                var fullZoom = options.mouseUnderlap || fullZoomKeyDown || viewerLocked;
+                const fullZoom = options.mouseUnderlap || fullZoomKeyDown || viewerLocked;
                 if (viewerLocked) {
                     imgFullSize.width(srcDetails.naturalWidth * zoomFactor);
                 } else if (fullZoom) {

--- a/js/hoverzoom.js
+++ b/js/hoverzoom.js
@@ -485,7 +485,7 @@ var hoverZoom = {
                 }
 
                 // width adjustment
-                const fullZoom = options.mouseUnderlap || fullZoomKeyDown || viewerLocked;
+                var fullZoom = options.mouseUnderlap || fullZoomKeyDown || viewerLocked;
                 if (viewerLocked) {
                     imgFullSize.width(srcDetails.naturalWidth * zoomFactor);
                 } else if (fullZoom) {

--- a/js/hoverzoom.js
+++ b/js/hoverzoom.js
@@ -485,9 +485,13 @@ var hoverZoom = {
                 }
 
                 // width adjustment
-                var fullZoom = options.mouseUnderlap || fullZoomKeyDown || viewerLocked;
+                const fullZoom = options.mouseUnderlap ||  viewerLocked;
+                const fullZoomKey = fullZoomKeyDown;
                 if (viewerLocked) {
                     imgFullSize.width(srcDetails.naturalWidth * zoomFactor);
+                } else if (fullZoomKey) {
+                    // naturalWidth replaced with wndWidth to make image fill window
+                    imgFullSize.width(Math.min(wndWidth, wndWidth - padding - 2 * scrollBarWidth)); 
                 } else if (fullZoom) {
                     imgFullSize.width(Math.min(srcDetails.naturalWidth * zoomFactor, wndWidth - padding - 2 * scrollBarWidth));
                 } else if (displayOnRight) {
@@ -2345,7 +2349,7 @@ var hoverZoom = {
             // for instance, on TripAdvisor:
             // img's src placeholder is replaced by real img url stored in data-lazyurl as user scrolls down
             $(document).on('scroll mousewheel', function() {
-                let scrollTop = window.pageYOffset || document.documentElement.scrollTop; // Credits: "https://github.com/qeremy/so/blob/master/so.dom.js#L426"
+                let scrollTop = window.scrollY || document.documentElement.scrollTop; // Credits: "https://github.com/qeremy/so/blob/master/so.dom.js#L426"
                 if (scrollTop < lastScrollTop) {
                     lastScrollTop = scrollTop < 0 ? 0 : scrollTop; // For Mobile or negative scrolling
                 } else if (scrollTop > lastScrollTop + deltaMin) {

--- a/js/hoverzoom.js
+++ b/js/hoverzoom.js
@@ -2345,7 +2345,7 @@ var hoverZoom = {
             // for instance, on TripAdvisor:
             // img's src placeholder is replaced by real img url stored in data-lazyurl as user scrolls down
             $(document).on('scroll mousewheel', function() {
-                let scrollTop = window.pageYOffset || document.documentElement.scrollTop; // Credits: "https://github.com/qeremy/so/blob/master/so.dom.js#L426"
+                let scrollTop = window.scrollY || window.pageYOffset || document.documentElement.scrollTop; // Credits: "https://github.com/qeremy/so/blob/master/so.dom.js#L426"
                 if (scrollTop < lastScrollTop) {
                     lastScrollTop = scrollTop < 0 ? 0 : scrollTop; // For Mobile or negative scrolling
                 } else if (scrollTop > lastScrollTop + deltaMin) {
@@ -3603,7 +3603,7 @@ var hoverZoom = {
             fontSize(options.fontSize);
 
             webSiteExcluded = null;
-            body100pct = (body.css('position') != 'static') || (body.css('padding-left') == '0px' && body.css('padding-right') == '0px' && body.css('margin-left') == '0px' && body.css('margin-right') == '0px' && body.css('max-width') == ('none' || '100%'));
+            body100pct = (body.css('position') != 'static') || (body.css('padding-left') == '0px' && body.css('padding-right') == '0px' && body.css('margin-left') == '0px' && body.css('margin-right') == '0px' && (body.css('max-width') == ('none' || '100%')));
             hz.pageGenerator = $('meta[name="generator"]').attr('content');
             prepareImgLinks();
             bindEvents();

--- a/js/hoverzoom.js
+++ b/js/hoverzoom.js
@@ -3603,7 +3603,7 @@ var hoverZoom = {
             fontSize(options.fontSize);
 
             webSiteExcluded = null;
-            body100pct = (body.css('position') != 'static') || (body.css('padding-left') == '0px' && body.css('padding-right') == '0px' && body.css('margin-left') == '0px' && body.css('margin-right') == '0px' && (body.css('max-width') == ('none' || '100%')));
+            body100pct = (body.css('position') != 'static') || (body.css('padding-left') == '0px' && body.css('padding-right') == '0px' && body.css('margin-left') == '0px' && body.css('margin-right') == '0px' && (body.css('max-width') == 'none' || body.css('max-width') == '100%'));
             hz.pageGenerator = $('meta[name="generator"]').attr('content');
             prepareImgLinks();
             bindEvents();

--- a/js/hoverzoom.js
+++ b/js/hoverzoom.js
@@ -2345,7 +2345,7 @@ var hoverZoom = {
             // for instance, on TripAdvisor:
             // img's src placeholder is replaced by real img url stored in data-lazyurl as user scrolls down
             $(document).on('scroll mousewheel', function() {
-                let scrollTop = window.scrollY || window.pageYOffset || document.documentElement.scrollTop; // Credits: "https://github.com/qeremy/so/blob/master/so.dom.js#L426"
+                let scrollTop = window.pageYOffset || document.documentElement.scrollTop; // Credits: "https://github.com/qeremy/so/blob/master/so.dom.js#L426"
                 if (scrollTop < lastScrollTop) {
                     lastScrollTop = scrollTop < 0 ? 0 : scrollTop; // For Mobile or negative scrolling
                 } else if (scrollTop > lastScrollTop + deltaMin) {

--- a/js/hoverzoom.js
+++ b/js/hoverzoom.js
@@ -3603,7 +3603,7 @@ var hoverZoom = {
             fontSize(options.fontSize);
 
             webSiteExcluded = null;
-            body100pct = (body.css('position') != 'static') || (body.css('padding-left') == '0px' && body.css('padding-right') == '0px' && body.css('margin-left') == '0px' && body.css('margin-right') == '0px');
+            body100pct = (body.css('position') != 'static') || (body.css('padding-left') == '0px' && body.css('padding-right') == '0px' && body.css('margin-left') == '0px' && body.css('margin-right') == '0px' && body.css('max-width') == ('none' || '100%'));
             hz.pageGenerator = $('meta[name="generator"]').attr('content');
             prepareImgLinks();
             bindEvents();


### PR DESCRIPTION
Variable 'body100pct' in hoverzoom.js is not picking up Fur Affinity using max-width which sets hzWindow position wrong when innerWidth is greater than max-width. This fix makes body100pct check if max-width is changed in the body's css, returning false if it is. 