### PR TITLE
Add import/export function

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -655,6 +655,14 @@
         "message": "Export",
         "description": "[options] Export a save string into the textarea"
     },
+    "optImport": {
+        "message": "Import Success!",
+        "description": "[options] Notification after successful import to options"
+    },
+    "optImportFailed": {
+        "message": "Import Failed",
+        "description": "[options] Notification after failed import to options"
+    },
     "optPageFAQ": {
         "message": "FAQ",
         "description": "[options] Page title for FAQ"

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -595,18 +595,18 @@
         "message": "caption",
         "description": "[options] Add download caption option"
     }, 
-  "optDownloadReplaceOriginalFilenameTooltip": {
-    "message": "Replace original filename or remove it if no value supplied (extension is preserved)",
-    "description": "[options] Tooltip for replace original filename when downloading option"
-  },
-  "optDownloadReplaceOriginalFilenamePlaceholder": {
-    "message": "Example: fullsize_image",
-    "description": "[options] Placeholder for download folder option"
-  },
-  "optDownloadReplaceOriginalFilename": {
-    "message": "On save, replace original filename by:",
-    "description": "[options] Replace original filename when downloading option"
-  },
+    "optDownloadReplaceOriginalFilenameTooltip": {
+        "message": "Replace original filename or remove it if no value supplied (extension is preserved)",
+        "description": "[options] Tooltip for replace original filename when downloading option"
+    },
+    "optDownloadReplaceOriginalFilenamePlaceholder": {
+        "message": "Example: fullsize_image",
+        "description": "[options] Placeholder for download folder option"
+    },
+    "optDownloadReplaceOriginalFilename": {
+        "message": "On save, replace original filename by:",
+        "description": "[options] Replace original filename when downloading option"
+    },
     "optSectionTroubleshooting": {
         "message": "Troubleshooting",
         "description": "[options] Page section for troubleshooting"
@@ -630,10 +630,30 @@
     "optSupportedVideoFormats": {
         "message": "Video :",
         "description": "[options] Page section for supported video formats"
-  },
-  "optSupportedAudioFormats": {
-    "message": "Audio :",
-    "description": "[options] Page section for supported audio formats"
+    },
+    "optSupportedAudioFormats": {
+        "message": "Audio :",
+        "description": "[options] Page section for supported audio formats"
+    },
+    "optSectionImportExportSettings": {
+        "message": "Import/Export",
+        "description": "[options] Page section for import/export"
+    },
+    "optSectionImportExportSettingsTooltip": {
+        "message": "Press export to get a string of your current settings. Press import to load your pasted settings",
+        "description": "[options] Tooltip for input and export options"
+    },
+    "optImportExportTextArea": {
+        "message": "Paste your saved settings here",
+        "description": "[options] Placeholder for import and export text area"
+    },
+    "optButtonImportSettings": {
+        "message": "Import",
+        "description": "[options] Import a save string from the textarea"
+    },
+    "optButtonExportSettings": {
+        "message": "Export",
+        "description": "[options] Export a save string into the textarea"
     },
     "optPageFAQ": {
         "message": "FAQ",

--- a/html/options.html
+++ b/html/options.html
@@ -565,6 +565,19 @@
                                 </li>
                             </ul>
                         </fieldset>
+                        <fieldset>
+                            <legend data-i18n="optSectionImportExportSettings"></legend>
+                            <ul>
+                                <div class="ttip" data-i18n-tooltip="optSectionImportExportSettings">
+                                    <div class="field">
+                                        <textarea class="input textarea" rows="5" id="txtBoxImportExportSettings" data-i18n-placeholder="optImportExportSettings"></textarea>
+                                        <div style="display:block; justify-content:flex-start; gap:10px;">
+                                            <div class="btn default"><a href="#" id="btnImportSettings" data-i18n="optButtonImportSettings"></a></div>
+                                            <div class="btn default"><a href="#" id="btnExportSettings" data-i18n="optButtonExportSettings"></a></div>
+                                    </div>
+                                </div>
+                            </ul>
+                        </fieldset>
                     </form>
                 </div>
                 <div class="tab-content">

--- a/html/options.html
+++ b/html/options.html
@@ -568,9 +568,9 @@
                         <fieldset>
                             <legend data-i18n="optSectionImportExportSettings"></legend>
                             <ul>
-                                <div class="ttip" data-i18n-tooltip="optSectionImportExportSettings">
+                                <div class="ttip" data-i18n-tooltip="optSectionImportExportSettingsTooltip">
                                     <div class="field">
-                                        <textarea class="input textarea" rows="5" id="txtBoxImportExportSettings" data-i18n-placeholder="optImportExportSettings"></textarea>
+                                        <textarea class="input textarea" rows="5" id="txtBoxImportExportSettings" data-i18n-placeholder="optImportExportTextArea"></textarea>
                                         <div style="display:block; justify-content:flex-start; gap:10px;">
                                             <div class="btn default"><a href="#" id="btnImportSettings" data-i18n="optButtonImportSettings"></a></div>
                                             <div class="btn default"><a href="#" id="btnExportSettings" data-i18n="optButtonExportSettings"></a></div>

--- a/js/common.js
+++ b/js/common.js
@@ -82,15 +82,11 @@ function loadFactorySettings() {
 
 // Load options from local storage
 // Return default values if none exist
-function loadOptions(importSettings = null) {
+function loadOptions() {
     var options;
 
     if (localStorage.options == null) {
         localStorage.options = '{}';
-    }
-
-    if (importSettings != null) {
-        localStorage.options = importSettings
     }
 
     options = JSON.parse(localStorage.options);  // TODO: Migrate to https://developer.chrome.com/extensions/storage

--- a/js/common.js
+++ b/js/common.js
@@ -82,7 +82,7 @@ function loadFactorySettings() {
 
 // Load options from local storage
 // Return default values if none exist
-function loadOptions() {
+function loadOptions(importSettings = false) {
     var options;
     if (localStorage.options == null) {
         localStorage.options = '{}';

--- a/js/common.js
+++ b/js/common.js
@@ -84,6 +84,11 @@ function loadFactorySettings() {
 // Return default values if none exist
 function loadOptions(importSettings = false) {
     var options;
+
+    if (importSettings) {
+        options = $('#txtBoxImportExportSettings').value
+    }
+
     if (localStorage.options == null) {
         localStorage.options = '{}';
     }

--- a/js/common.js
+++ b/js/common.js
@@ -84,11 +84,9 @@ function loadFactorySettings() {
 // Return default values if none exist
 function loadOptions() {
     var options;
-
     if (localStorage.options == null) {
         localStorage.options = '{}';
     }
-
     options = JSON.parse(localStorage.options);  // TODO: Migrate to https://developer.chrome.com/extensions/storage
 
     options.extensionEnabled = options.hasOwnProperty('extensionEnabled') ? options.extensionEnabled : factorySettings.extensionEnabled;

--- a/js/common.js
+++ b/js/common.js
@@ -82,16 +82,17 @@ function loadFactorySettings() {
 
 // Load options from local storage
 // Return default values if none exist
-function loadOptions(importSettings = false) {
+function loadOptions(importSettings = null) {
     var options;
-
-    if (importSettings) {
-        options = $('#txtBoxImportExportSettings').value
-    }
 
     if (localStorage.options == null) {
         localStorage.options = '{}';
     }
+
+    if (importSettings != null) {
+        localStorage.options = importSettings
+    }
+
     options = JSON.parse(localStorage.options);  // TODO: Migrate to https://developer.chrome.com/extensions/storage
 
     options.extensionEnabled = options.hasOwnProperty('extensionEnabled') ? options.extensionEnabled : factorySettings.extensionEnabled;

--- a/js/options.js
+++ b/js/options.js
@@ -724,10 +724,13 @@ function importSettings() {
     let jsonImport;
     try {
         jsonImport = JSON.parse($('#txtBoxImportExportSettings')[0].value);
-        // Checks for a few HZ+ settings to test if it's a valid HZ+ JSON
-        if (!jsonImport.darkMode || !jsonImport.disabledPlugins || !jsonImport.fullZoomKey) {
-            throw new Error('Not a valid HZ+ import JSON')
-        }
+        // Checks if a few HZ+ settings are defined to test if it's a valid HZ+ JSON
+        const jsonTest = [jsonImport.centerImages, jsonImport.fullZoomKey, jsonImport.hideMouseCursor];
+        jsonTest.forEach((variable) => {
+            if (typeof variable === 'undefined') {
+                throw new Error('Not a valid HZ+ import JSON');
+            }
+        });
     } catch (e) {
         displayMsg(ImportFail);
         return false;

--- a/js/options.js
+++ b/js/options.js
@@ -151,10 +151,8 @@ function saveOptions(exportSettings = false) {
 
     if (exportSettings) { return JSON.stringify(options) }
     localStorage.options = JSON.stringify(options);
-    
     sendOptions(options);
-    restoreOptions();
-    
+    restoreOptions();  
 
     return false;
 }
@@ -719,8 +717,9 @@ function enableAllPlugins() {
     $('input.chkPlugin').each(function() { $(this).trigger('gumby.check'); })
 }
 
+//Checks if string is JSON. 
+//If yes, imports settings and clears textarea.
 function importSettings() {
-    //Checks if string is JSON
     let jsonImport;
     try {
         jsonImport = JSON.parse($('#txtBoxImportExportSettings')[0].value);

--- a/js/options.js
+++ b/js/options.js
@@ -663,6 +663,7 @@ $(function () {
     $('#btnReset').click(function() { restoreOptionsFromFactorySettings(); displayMsg(Reset); return false; });
     $('#btnDisableAllPlugins').click(function() { disableAllPlugins(); return false; });
     $('#btnEnableAllPlugins').click(function() { enableAllPlugins(); return false; });
+    $('#btnImportSettings').click(function() { importSettings(); return false; });
     $('#btnExportSettings').click(function() { exportSettings(); return false; });
     $('#chkWhiteListMode').parent().on('gumby.onChange', chkWhiteListModeOnChange);
     $('#txtZoomFactor').change(percentageOnChange);
@@ -708,6 +709,10 @@ function disableAllPlugins() {
 
 function enableAllPlugins() {
     $('input.chkPlugin').each(function() { $(this).trigger('gumby.check'); })
+}
+
+function importSettings() {
+    //$('txtBoxImportExportSettings').each(function() { $(this).trigger('gumby.check'); })
 }
 
 function exportSettings() {

--- a/js/options.js
+++ b/js/options.js
@@ -724,6 +724,10 @@ function importSettings() {
     let jsonImport;
     try {
         jsonImport = JSON.parse($('#txtBoxImportExportSettings')[0].value);
+        // Checks for a few HZ+ settings to test if it's a valid HZ+ JSON
+        if (!jsonImport.darkMode || !jsonImport.disabledPlugins) {
+            throw new Error('Not a valid HZ+ import JSON')
+        }
     } catch (e) {
         displayMsg(ImportFail);
         return false;

--- a/js/options.js
+++ b/js/options.js
@@ -212,6 +212,7 @@ function restoreOptions(optionsFromFactorySettings) {
     $('#rngFontSize').val(parseInt(options.fontSize));
     $('#txtFontSize').val(parseInt(options.fontSize));
     $('#chkFontOutline').trigger(options.fontOutline ? 'gumby.check' : 'gumby.uncheck');
+    $('#txtBoxImportExportSettings').val('')
 
     if (options.frameBackgroundColor == "") {
         initColorPicker('#ffffff');

--- a/js/options.js
+++ b/js/options.js
@@ -634,6 +634,8 @@ function initColorPicker(color){
 const Saved = Symbol("saved");
 const Cancel = Symbol("cancel");
 const Reset = Symbol("reset");
+const Imported = Symbol("imported");
+const ImportFail = Symbol("importFail");
 function displayMsg(msg) {
     switch (msg)  {
         case Saved:
@@ -645,11 +647,11 @@ function displayMsg(msg) {
         case Reset:
             $('#msgtxt').removeClass().addClass('centered text-center alert info').text(chrome.i18n.getMessage('optReset')).clearQueue().animate({opacity:1}, 500).delay(5000).animate({opacity:0}, 500);
             break;
-        case Import:
+        case Imported:
             $('#msgtxt').removeClass().addClass('centered text-center alert success').text(chrome.i18n.getMessage('optImport')).clearQueue().animate({opacity:1}, 500).delay(5000).animate({opacity:0}, 500);
             break;
         case ImportFail:
-            $('#msgtxt').removeClass().addClass('centered text-center alert warning').text(chrome.i18n.getMessage('optImportFailed')).clearQueue().animate({opacity:1}, 500).delay(5000).animate({opacity:0}, 500);
+            $('#msgtxt').removeClass().addClass('centered text-center alert danger').text(chrome.i18n.getMessage('optImportFailed')).clearQueue().animate({opacity:1}, 500).delay(5000).animate({opacity:0}, 500);
             break;
         default:
             break;
@@ -727,7 +729,7 @@ function importSettings() {
         displayMsg(ImportFail)
         return false;
     }
-    displayMsg(Import)
+    displayMsg(Imported)
     console.log('is json')
     //loadOptions(true);
 }

--- a/js/options.js
+++ b/js/options.js
@@ -151,6 +151,7 @@ function saveOptions(exportSettings = false) {
 
     if (exportSettings) { return JSON.stringify(options) }
     localStorage.options = JSON.stringify(options);
+    
     sendOptions(options);
     restoreOptions();
 

--- a/js/options.js
+++ b/js/options.js
@@ -719,7 +719,17 @@ function enableAllPlugins() {
 }
 
 function importSettings() {
-    //$('txtBoxImportExportSettings').each(function() { $(this).trigger('gumby.check'); })
+    let jsonString = $('#txtBoxImportExportSettings').value
+    try {
+        JSON.parse(jsonString);
+    } catch (e) {
+        console.log('is not json')
+        displayMsg(ImportFail)
+        return false;
+    }
+    displayMsg(Import)
+    console.log('is json')
+    //loadOptions(true);
 }
 
 function exportSettings() {

--- a/js/options.js
+++ b/js/options.js
@@ -149,8 +149,8 @@ function saveOptions(exportSettings = false) {
     options.useSeparateTabOrWindowForUnloadableUrlsEnabled = $('#chkUseSeparateTabOrWindowForUnloadableUrlsEnabled')[0].checked;
     options.useSeparateTabOrWindowForUnloadableUrls = $('#selectUseSeparateTabOrWindowForUnloadableUrls').val();
 
+    if (exportSettings) { return JSON.stringify(options) }
     localStorage.options = JSON.stringify(options);
-    if (exportSettings) { return localStorage.options }
     
     sendOptions(options);
     restoreOptions();

--- a/js/options.js
+++ b/js/options.js
@@ -150,9 +150,11 @@ function saveOptions() {
     options.useSeparateTabOrWindowForUnloadableUrls = $('#selectUseSeparateTabOrWindowForUnloadableUrls').val();
 
     localStorage.options = JSON.stringify(options);
-
+    if (exportSettings) { return localStorage.options }
+    
     sendOptions(options);
     restoreOptions();
+    
 
     return false;
 }
@@ -661,6 +663,7 @@ $(function () {
     $('#btnReset').click(function() { restoreOptionsFromFactorySettings(); displayMsg(Reset); return false; });
     $('#btnDisableAllPlugins').click(function() { disableAllPlugins(); return false; });
     $('#btnEnableAllPlugins').click(function() { enableAllPlugins(); return false; });
+    $('#btnExportSettings').click(function() { exportSettings(); return false; });
     $('#chkWhiteListMode').parent().on('gumby.onChange', chkWhiteListModeOnChange);
     $('#txtZoomFactor').change(percentageOnChange);
     $('#txtPicturesOpacity').change(percentageOnChange);
@@ -705,6 +708,10 @@ function disableAllPlugins() {
 
 function enableAllPlugins() {
     $('input.chkPlugin').each(function() { $(this).trigger('gumby.check'); })
+}
+
+function exportSettings() {
+    $('#txtBoxImportExportSettings').val(saveOptions(true));
 }
 
 // highlight item if modified, unhighlight if not modified

--- a/js/options.js
+++ b/js/options.js
@@ -725,7 +725,7 @@ function importSettings() {
     try {
         jsonImport = JSON.parse($('#txtBoxImportExportSettings')[0].value);
         // Checks for a few HZ+ settings to test if it's a valid HZ+ JSON
-        if (!jsonImport.darkMode || !jsonImport.disabledPlugins) {
+        if (!jsonImport.darkMode || !jsonImport.disabledPlugins || !jsonImport.fullZoomKey) {
             throw new Error('Not a valid HZ+ import JSON')
         }
     } catch (e) {

--- a/js/options.js
+++ b/js/options.js
@@ -212,7 +212,6 @@ function restoreOptions(optionsFromFactorySettings) {
     $('#rngFontSize').val(parseInt(options.fontSize));
     $('#txtFontSize').val(parseInt(options.fontSize));
     $('#chkFontOutline').trigger(options.fontOutline ? 'gumby.check' : 'gumby.uncheck');
-    $('#txtBoxImportExportSettings').val('');
 
     if (options.frameBackgroundColor == "") {
         initColorPicker('#ffffff');
@@ -722,16 +721,16 @@ function enableAllPlugins() {
 
 function importSettings() {
     //Checks if string is JSON
-    let jsonString = $('#txtBoxImportExportSettings')[0].value
+    let jsonImport;
     try {
-        JSON.parse(jsonString);
+        jsonImport = JSON.parse($('#txtBoxImportExportSettings')[0].value);
     } catch (e) {
-        displayMsg(ImportFail)
+        displayMsg(ImportFail);
         return false;
     }
-    displayMsg(Imported)
-    loadOptions(jsonString);
-    $('#txtBoxImportExportSettings').val('')
+    displayMsg(Imported);
+    restoreOptions(Object.assign({}, jsonImport));
+    $('#txtBoxImportExportSettings').val('');
 }
 
 function exportSettings() {

--- a/js/options.js
+++ b/js/options.js
@@ -151,7 +151,7 @@ function saveOptions(exportSettings = false) {
 
     if (exportSettings) { return JSON.stringify(options) }
     localStorage.options = JSON.stringify(options);
-    
+
     sendOptions(options);
     restoreOptions();
 

--- a/js/options.js
+++ b/js/options.js
@@ -152,7 +152,7 @@ function saveOptions(exportSettings = false) {
     if (exportSettings) { return JSON.stringify(options) }
     localStorage.options = JSON.stringify(options);
     sendOptions(options);
-    restoreOptions();  
+    restoreOptions();
 
     return false;
 }

--- a/js/options.js
+++ b/js/options.js
@@ -212,7 +212,7 @@ function restoreOptions(optionsFromFactorySettings) {
     $('#rngFontSize').val(parseInt(options.fontSize));
     $('#txtFontSize').val(parseInt(options.fontSize));
     $('#chkFontOutline').trigger(options.fontOutline ? 'gumby.check' : 'gumby.uncheck');
-    $('#txtBoxImportExportSettings').val('')
+    $('#txtBoxImportExportSettings').val('');
 
     if (options.frameBackgroundColor == "") {
         initColorPicker('#ffffff');

--- a/js/options.js
+++ b/js/options.js
@@ -721,17 +721,17 @@ function enableAllPlugins() {
 }
 
 function importSettings() {
-    let jsonString = $('#txtBoxImportExportSettings').value
+    //Checks if string is JSON
+    let jsonString = $('#txtBoxImportExportSettings')[0].value
     try {
         JSON.parse(jsonString);
     } catch (e) {
-        console.log('is not json')
         displayMsg(ImportFail)
         return false;
     }
     displayMsg(Imported)
-    console.log('is json')
-    //loadOptions(true);
+    loadOptions(jsonString);
+    $('#txtBoxImportExportSettings').val('')
 }
 
 function exportSettings() {

--- a/js/options.js
+++ b/js/options.js
@@ -645,6 +645,12 @@ function displayMsg(msg) {
         case Reset:
             $('#msgtxt').removeClass().addClass('centered text-center alert info').text(chrome.i18n.getMessage('optReset')).clearQueue().animate({opacity:1}, 500).delay(5000).animate({opacity:0}, 500);
             break;
+        case Import:
+            $('#msgtxt').removeClass().addClass('centered text-center alert success').text(chrome.i18n.getMessage('optImport')).clearQueue().animate({opacity:1}, 500).delay(5000).animate({opacity:0}, 500);
+            break;
+        case ImportFail:
+            $('#msgtxt').removeClass().addClass('centered text-center alert warning').text(chrome.i18n.getMessage('optImportFailed')).clearQueue().animate({opacity:1}, 500).delay(5000).animate({opacity:0}, 500);
+            break;
         default:
             break;
     }

--- a/js/options.js
+++ b/js/options.js
@@ -149,7 +149,10 @@ function saveOptions(exportSettings = false) {
     options.useSeparateTabOrWindowForUnloadableUrlsEnabled = $('#chkUseSeparateTabOrWindowForUnloadableUrlsEnabled')[0].checked;
     options.useSeparateTabOrWindowForUnloadableUrls = $('#selectUseSeparateTabOrWindowForUnloadableUrls').val();
 
-    if (exportSettings) { return JSON.stringify(options) }
+    if (exportSettings) { 
+        $('#txtBoxImportExportSettings').val(JSON.stringify(options));
+        return false;
+    }
     localStorage.options = JSON.stringify(options);
 
     sendOptions(options);
@@ -736,12 +739,12 @@ function importSettings() {
         return false;
     }
     displayMsg(Imported);
-    restoreOptions(Object.assign({}, jsonImport));
+    restoreOptions({jsonImport});
     $('#txtBoxImportExportSettings').val('');
 }
 
 function exportSettings() {
-    $('#txtBoxImportExportSettings').val(saveOptions(true));
+    saveOptions(true);
 }
 
 // highlight item if modified, unhighlight if not modified

--- a/js/options.js
+++ b/js/options.js
@@ -151,13 +151,12 @@ function saveOptions(exportSettings = false) {
 
     if (exportSettings) { 
         $('#txtBoxImportExportSettings').val(JSON.stringify(options));
-        return false;
+    } else {
+        localStorage.options = JSON.stringify(options);
+
+        sendOptions(options);
+        restoreOptions();
     }
-    localStorage.options = JSON.stringify(options);
-
-    sendOptions(options);
-    restoreOptions();
-
     return false;
 }
 

--- a/js/options.js
+++ b/js/options.js
@@ -77,7 +77,7 @@ function loadKeys(sel) {
 
 // Saves options to localStorage.
 // TODO: Migrate to https://developer.chrome.com/extensions/storage
-function saveOptions() {
+function saveOptions(exportSettings = false) {
     options.extensionEnabled = $('#chkExtensionEnabled')[0].checked;
     options.darkMode = $('#chkDarkMode')[0].checked;
     options.zoomFactor = $('#txtZoomFactor')[0].value;


### PR DESCRIPTION
Adds an import and export box under the "Advanced" tab.
- Exports options in a json string format
- Has checks for valid HZ+ JSON string when importing
- Shows changed options upon importing (glows like when changing options)

Remedies #804 and #687

![firefox_39Oah05hIH](https://github.com/user-attachments/assets/708be4e0-d2b1-4671-928a-e456365778f7)
