### PR TITLE
Add middle click and right click as action keys

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -58,7 +58,7 @@ var factorySettings = {
     detailsLocation : 'none',
     fontSize : 11,
     fontOutline : false,
-    actionKey : -5,
+    actionKey : 0,
     toggleKey : 69,
     fullZoomKey : 90,
     copyImageKey: 67,

--- a/js/common.js
+++ b/js/common.js
@@ -58,7 +58,7 @@ var factorySettings = {
     detailsLocation : 'none',
     fontSize : 11,
     fontOutline : false,
-    actionKey : 0,
+    actionKey : -5,
     toggleKey : 69,
     fullZoomKey : 90,
     copyImageKey: 67,

--- a/js/hoverzoom.js
+++ b/js/hoverzoom.js
@@ -1083,7 +1083,7 @@ var hoverZoom = {
                     return;
                 case options.toggleKey:
                     toggleKey()
-                    break;
+                    return;
                 default:
                     return;
             }
@@ -1143,7 +1143,6 @@ var hoverZoom = {
 
         function documentMouseUp(event) {
             if (event.button === 0) return; // If left click, return
-
             const mouseButtonKey = -event.button;
             switch (mouseButtonKey) {
                 case options.actionKey:
@@ -2459,7 +2458,8 @@ var hoverZoom = {
             $(document).mouseup(prepareImgLinksAsync);
 
             $(document).contextmenu(documentContextMenu);
-            $(document).mousemove(documentMouseMove).mousedown(documentMouseDown).mouseup(documentMouseUp).mouseleave(cancelSourceLoading);
+            $(document).mousemove(documentMouseMove).mousedown(documentMouseDown).mouseleave(cancelSourceLoading);
+            $(document).on('mouseup', function(event) { documentMouseUp(event); })
             $(document).keydown(documentOnKeyDown).keyup(documentOnKeyUp);
             if (options.galleriesMouseWheel) {
                 window.addEventListener('wheel', documentOnMouseWheel, {passive: false});

--- a/js/hoverzoom.js
+++ b/js/hoverzoom.js
@@ -2636,7 +2636,7 @@ var hoverZoom = {
 
             // Toggle key is pressed down
             if (keyCode === options.toggleKey) {
-                toggleKey()
+                toggleKey();
             }
 
             // Action key (zoom image) is pressed down
@@ -2660,13 +2660,13 @@ var hoverZoom = {
             // close key (close zoomed image) is pressed down
             // => zoomed image is closed immediately
             if (keyCode === options.closeKey) {
-                closeKey()
+                closeKey();
             }
 
             // hide key (hide zoomed image) is pressed down
             // => zoomed image remains hidden until key is released
             if (keyCode === options.hideKey && !hideKeyDown) {
-                hideKey()
+                hideKey();
             }
 
             // the following keys are processed only if an image is displayed

--- a/js/hoverzoom.js
+++ b/js/hoverzoom.js
@@ -1049,57 +1049,25 @@ var hoverZoom = {
         let longRightPressTimer; // create timer
         let longMiddlePressTimer; // creates separate timer so they don't interfere
         let longPress = false;
-
-        function documentContextMenu(event) {
-            // If it's been less than 300ms since right click, lock viewer and prevent context menu.
-            let lockElapsed = event.timeStamp - viewerClickTime;
-            if (imgFullSize && !viewerLocked && options.lockImageKey === -2 && lockElapsed < 300) {
-                lockViewer();
-                event.preventDefault();
-            }
-            if (longPress) {
-                longPress = false;
-                event.preventDefault();
+        
+        function mouseButtonKeyHandler(mouseButtonKey){
+            const timerDelay = 150;
+            console.log(mouseButtonKey)
+            if (mouseButtonKey === -2){
+                longRightPressTimer = setTimeout(longClick.bind(this), timerDelay, mouseButtonKey); // create a new timer for this click
+            } else {
+                longMiddlePressTimer = setTimeout(longClick.bind(this), timerDelay, mouseButtonKey); // create a new timer for this click
             }
         }
 
-        function documentMouseDown(event) {
-            // Gets mouse button key from event.button
-            const mouseButtonKey = -event.button
-            switch (mouseButtonKey) {
-                case options.actionKey:
-                    if (mouseButtonKey === -2){
-                        clearTimeout(longRightPressTimer);
-                        longRightPressTimer = setTimeout(longClick.bind(this), 150, mouseButtonKey); // create a new timer for this click
-                    } else {
-                        clearTimeout(longMiddlePressTimer);
-                        longMiddlePressTimer = setTimeout(longClick.bind(this), 150, mouseButtonKey); // create a new timer for this click
-                    }
-                    break;
-                default:
-                    break;
-            }
-            // The following only trigger when image is displayed
-            if (imgFullSize) { 
-                switch (mouseButtonKey) {
-                    // Right click pressed and lockImageKey or actionKey is set to special value for right click (-1).
-                    case options.lockImageKey:
-                        viewerClickTime = event.timeStamp;
-                        break;
-                    default:
-                        return;
-                }
-                if (event.target !== hz.hzViewer[0] && event.target !== imgFullSize[0]) {
-                    // if image is locked and left click is pressed outside of locked image
-                    if (viewerLocked && event.button === 0) {
-                        viewerLocked = false;
-                    }
-                    cancelSourceLoading();
-                    restoreTitles();
-                }
+        function clearMouseButtonTimers(mouseButtonKey){
+            if (mouseButtonKey === -2){
+                clearTimeout(longRightPressTimer);
+            } else {
+                clearTimeout(longMiddlePressTimer);
             }
         }
-
+        
         function longClick(mouseButtonKey) {
             longPress = true;
             switch (mouseButtonKey) {
@@ -1110,8 +1078,50 @@ var hoverZoom = {
                         return false;
                     }
                     break;
+                case options.lockKey:
+                    lockViewer();
+                    return;
                 default:
                     return;
+            }
+        }
+
+        function documentContextMenu(event) {
+            // If it's been less than 300ms since right click, lock viewer and prevent context menu.
+            if (longPress) {
+                longPress = false;
+                event.preventDefault();
+            }
+        }
+
+        function documentMouseDown(event) {
+            // Gets mouse button key from event.button
+            const mouseButtonKey = -event.button
+            console.log(options.actionKey)
+            switch (mouseButtonKey) {
+                case options.actionKey:
+                    mouseButtonKeyHandler(mouseButtonKey).bind(this);
+                    return;
+                default:
+                    break;
+            }
+            // The following only trigger when image is displayed
+            if (imgFullSize) { 
+                switch (mouseButtonKey) {
+                    case options.lockImageKey:
+                        mouseButtonKeyHandler(mouseButtonKey).bind(this);
+                        return;
+                    default:
+                        break;
+                }
+                if (mouseButtonKey === 0 && event.target !== hz.hzViewer[0] && event.target !== imgFullSize[0]) {
+                    // if image is locked and left click is pressed outside of locked image
+                    if (viewerLocked) {
+                        viewerLocked = false;
+                    }
+                    cancelSourceLoading();
+                    restoreTitles();
+                }
             }
         }
 
@@ -1119,16 +1129,12 @@ var hoverZoom = {
             const mouseButtonKey = -event.button
             switch (mouseButtonKey) {
                 case options.actionKey:
-                    if (mouseButtonKey === -2){
-                        clearTimeout(longRightPressTimer);
-                    } else {
-                        clearTimeout(longMiddlePressTimer);
-                    }
+                    clearMouseButtonTimers;
                     if (actionKeyDown) {
                         actionKeyDown = false;
                         closeHoverZoomViewer();
                     }
-                    break;
+                    return;
                 default:
                     break;
             }

--- a/js/hoverzoom.js
+++ b/js/hoverzoom.js
@@ -1053,7 +1053,7 @@ var hoverZoom = {
         function documentContextMenu(event) {
             // If it's been less than 300ms since right click, lock viewer and prevent context menu.
             let lockElapsed = event.timeStamp - viewerClickTime;
-            if (imgFullSize && !viewerLocked && options.lockImageKey === -1 && lockElapsed < 300) {
+            if (imgFullSize && !viewerLocked && options.lockImageKey === -2 && lockElapsed < 300) {
                 lockViewer();
                 event.preventDefault();
             }
@@ -1064,8 +1064,8 @@ var hoverZoom = {
         }
 
         function documentMouseDown(event) {
-            const mouseButtonKey = event.button[0,-2,-1,0,0];
-            // The following trigger for right click
+            // Gets mouse button key from event.button
+            const mouseButtonKey = -event.button
             switch (mouseButtonKey) {
                 case options.actionKey:
                     if (mouseButtonKey === -2){
@@ -1116,7 +1116,7 @@ var hoverZoom = {
         }
 
         function documentMouseUp(event) {
-            const mouseButtonKey = event.button[0,-2,-1,0,0];
+            const mouseButtonKey = -event.button
             switch (mouseButtonKey) {
                 case options.actionKey:
                     if (mouseButtonKey === -2){

--- a/js/hoverzoom.js
+++ b/js/hoverzoom.js
@@ -1050,12 +1050,12 @@ var hoverZoom = {
         let longMiddlePressTimer; // creates separate timer so they don't interfere
         let longPress = false;
         
-        function mouseButtonKeyHandler(mouseButtonKey) {
+        function mouseButtonKeyHandler(mouseButtonKey, img) {
             const timerDelay = 150;
             if (mouseButtonKey === -2){
-                longRightPressTimer = setTimeout(longClick.bind(this), timerDelay, mouseButtonKey);
+                longRightPressTimer = setTimeout(longClick.bind(img), timerDelay, mouseButtonKey);
             } else {
-                longMiddlePressTimer = setTimeout(longClick.bind(this), timerDelay, mouseButtonKey);
+                longMiddlePressTimer = setTimeout(longClick.bind(img), timerDelay, mouseButtonKey);
             }
         }
 

--- a/js/hoverzoom.js
+++ b/js/hoverzoom.js
@@ -1060,6 +1060,7 @@ var hoverZoom = {
             if (imgFullSize && !viewerLocked && options.lockImageKey === -1 && event.button === 2) {
                 lockViewerClickTime = event.timeStamp;
             } else if (imgFullSize && event.target !== hz.hzViewer[0] && event.target !== imgFullSize[0]) {
+                // if image is locked and left click is pressed outside of locked image
                 if (viewerLocked && event.button === 0) {
                     viewerLocked = false;
                 }

--- a/js/hoverzoom.js
+++ b/js/hoverzoom.js
@@ -1142,22 +1142,21 @@ var hoverZoom = {
             const mouseButtonKey = -event.button
             switch (mouseButtonKey) {
                 case options.actionKey:
-                    clearMouseButtonTimers(mouseButtonKey);
                     if (actionKeyDown) {
                         actionKeyDown = false;
                         closeHoverZoomViewer();
                     }
-                    return;
+                    break;
                 default:
-                    clearMouseButtonTimers(mouseButtonKey);
+                    if (imgFullSize) { 
+                        switch (mouseButtonKey) {
+                            default:
+                                break;
+                        }
+                    }
                     break;
             }
-            if (imgFullSize) { 
-                switch (mouseButtonKey) {
-                    default:
-                        return;
-                }
-            }
+            clearMouseButtonTimers(mouseButtonKey);
         }
 
         // select correct font size for msg depending on img or video width

--- a/js/hoverzoom.js
+++ b/js/hoverzoom.js
@@ -1052,7 +1052,7 @@ var hoverZoom = {
         
         function mouseButtonKeyHandler(mouseButtonKey, img) {
             const timerDelay = 150;
-            if (mouseButtonKey === -2){
+            if (mouseButtonKey === -2) {
                 longRightPressTimer = setTimeout(longClick.bind(img), timerDelay, mouseButtonKey);
             } else {
                 longMiddlePressTimer = setTimeout(longClick.bind(img), timerDelay, mouseButtonKey);

--- a/js/hoverzoom.js
+++ b/js/hoverzoom.js
@@ -1081,6 +1081,9 @@ var hoverZoom = {
                 case options.lockImageKey:
                     lockViewer();
                     return;
+                case options.toggleKey:
+                    toggleKey()
+                    break;
                 default:
                     return;
             }
@@ -1099,7 +1102,12 @@ var hoverZoom = {
             const mouseButtonKey = -event.button
             switch (mouseButtonKey) {
                 case options.actionKey:
-                    mouseButtonKeyHandler(mouseButtonKey).bind(this);
+                case options.toggleKey:
+                //case options.fullZoomKey:
+                //case options.closeKey:
+                //case options.hideKey:
+                        event.preventDefault();
+                    mouseButtonKeyHandler(mouseButtonKey, this);
                     return;
                 default:
                     break;
@@ -1108,6 +1116,12 @@ var hoverZoom = {
             if (imgFullSize) { 
                 switch (mouseButtonKey) {
                     case options.lockImageKey:
+                    case options.copyImageKey:
+                    case options.copyImageUrlKey:
+                    case options.flipImageKey:
+                    case options.openImageInWindowKey:
+                    case options.openImageInTabKey:
+                    case options.saveImageKey:
                         mouseButtonKeyHandler(mouseButtonKey);
                         return;
                     default:
@@ -2509,6 +2523,21 @@ var hoverZoom = {
             }
         }
 
+        function toggleKey() {
+            options.extensionEnabled = !options.extensionEnabled;
+            if (!options.extensionEnabled) {
+                // close zoomed image or video
+                viewerLocked = false;
+                if (hz.hzViewer) {
+                    stopMedias();
+                    hz.hzViewer.hide();
+                }
+                if (imgFullSize) {
+                    return false;
+                }
+            }
+        }
+
         function documentOnKeyDown(event) {
             // Skips if an input controlled is focused
             if (event.target && ['INPUT','TEXTAREA','SELECT'].indexOf(event.target.tagName) > -1) {
@@ -2519,18 +2548,7 @@ var hoverZoom = {
 
             // Toggle key is pressed down
             if (keyCode === options.toggleKey) {
-                options.extensionEnabled = !options.extensionEnabled;
-                if (!options.extensionEnabled) {
-                    // close zoomed image or video
-                    viewerLocked = false;
-                    if (hz.hzViewer) {
-                        stopMedias();
-                        hz.hzViewer.hide();
-                    }
-                    if (imgFullSize) {
-                        return false;
-                    }
-                }
+                toggleKey()
             }
 
             // Action key (zoom image) is pressed down

--- a/js/hoverzoom.js
+++ b/js/hoverzoom.js
@@ -1015,7 +1015,7 @@ var hoverZoom = {
                     if (!imgFullSize) {
                         hz.currentLink = links;
 
-                        if (links.data().hoverZoomSrc && (options.actionKey === -5 || actionKeyDown)) {
+                        if (links.data().hoverZoomSrc && (!options.actionKey || actionKeyDown)) {
                             const src = hoverZoom.getFullUrl(links.data().hoverZoomSrc[hoverZoomSrcIndex]);
                             const audioSrc = links.data().hoverZoomAudioSrc ? hoverZoom.getFullUrl(links.data().hoverZoomAudioSrc[hoverZoomSrcIndex]) : undefined;
 
@@ -1052,7 +1052,7 @@ var hoverZoom = {
         
         function mouseButtonKeyHandler(mouseButtonKey, img) {
             const timerDelay = 150;
-            if (mouseButtonKey === -2) {
+            if (mouseButtonKey === -1) {
                 longRightPressTimer = setTimeout(longClick.bind(img), timerDelay, mouseButtonKey);
             } else {
                 longMiddlePressTimer = setTimeout(longClick.bind(img), timerDelay, mouseButtonKey);
@@ -1060,7 +1060,7 @@ var hoverZoom = {
         }
 
         function clearMouseButtonTimers(mouseButtonKey) {
-            if (mouseButtonKey === -2) {
+            if (mouseButtonKey === -1) {
                 clearTimeout(longRightPressTimer);
             } else {
                 longPress = false;
@@ -1168,7 +1168,7 @@ var hoverZoom = {
             }
 
             // Gets mouse button key from event.button
-            const mouseButtonKey = -event.button
+            const mouseButtonKey = [null,-2,-1,null,null][event.button]; // -2 is middle click, -1 is right click
             switch (mouseButtonKey) {
                 case options.actionKey:
                 case options.toggleKey:
@@ -1200,7 +1200,7 @@ var hoverZoom = {
 
         function documentMouseUp(event) {
             if (event.button === 0) return; // If left click, return
-            const mouseButtonKey = -event.button;
+            const mouseButtonKey = [null,-2,-1,null,null][event.button]; // -2 is middle click, -1 is right click
             switch (mouseButtonKey) {
                 case options.actionKey:
                     if (actionKeyDown) {

--- a/js/hoverzoom.js
+++ b/js/hoverzoom.js
@@ -1015,7 +1015,7 @@ var hoverZoom = {
                     if (!imgFullSize) {
                         hz.currentLink = links;
 
-                        if (links.data().hoverZoomSrc && (!options.actionKey || actionKeyDown)) {
+                        if (links.data().hoverZoomSrc && (options.actionKey === -5 || actionKeyDown)) {
                             const src = hoverZoom.getFullUrl(links.data().hoverZoomSrc[hoverZoomSrcIndex]);
                             const audioSrc = links.data().hoverZoomAudioSrc ? hoverZoom.getFullUrl(links.data().hoverZoomAudioSrc[hoverZoomSrcIndex]) : undefined;
 
@@ -1052,10 +1052,10 @@ var hoverZoom = {
         
         function mouseButtonKeyHandler(mouseButtonKey){
             const timerDelay = 150;
-            console.log(mouseButtonKey)
             if (mouseButtonKey === -2){
                 longRightPressTimer = setTimeout(longClick.bind(this), timerDelay, mouseButtonKey); // create a new timer for this click
             } else {
+                longPress = false;
                 longMiddlePressTimer = setTimeout(longClick.bind(this), timerDelay, mouseButtonKey); // create a new timer for this click
             }
         }
@@ -1078,7 +1078,7 @@ var hoverZoom = {
                         return false;
                     }
                     break;
-                case options.lockKey:
+                case options.lockImageKey:
                     lockViewer();
                     return;
                 default:
@@ -1097,7 +1097,6 @@ var hoverZoom = {
         function documentMouseDown(event) {
             // Gets mouse button key from event.button
             const mouseButtonKey = -event.button
-            console.log(options.actionKey)
             switch (mouseButtonKey) {
                 case options.actionKey:
                     mouseButtonKeyHandler(mouseButtonKey).bind(this);

--- a/js/hoverzoom.js
+++ b/js/hoverzoom.js
@@ -1046,7 +1046,8 @@ var hoverZoom = {
             }
         }
 
-        let longPressTimer; //create timer
+        let longRightPressTimer; // create timer
+        let longMiddlePressTimer; // creates separate timer so they don't interfere
         let longPress = false;
 
         function documentContextMenu(event) {
@@ -1067,11 +1068,16 @@ var hoverZoom = {
             // The following trigger for right click
             switch (mouseButtonKey) {
                 case options.actionKey:
-                    clearTimeout(longPressTimer);                                            // clear any running timers
-                    longPressTimer = setTimeout(longRightClick.bind(this), pressDelay, mouseButtonKey); // create a new timer for this click
+                    if (mouseButtonKey === -2){
+                        clearTimeout(longRightPressTimer);
+                        longRightPressTimer = setTimeout(longClick.bind(this), 150, mouseButtonKey); // create a new timer for this click
+                    } else {
+                        clearTimeout(longMiddlePressTimer);
+                        longMiddlePressTimer = setTimeout(longClick.bind(this), 150, mouseButtonKey); // create a new timer for this click
+                    }
                     break;
                 default:
-                    return;
+                    break;
             }
             // The following only trigger when image is displayed
             if (imgFullSize) { 
@@ -1094,7 +1100,8 @@ var hoverZoom = {
             }
         }
 
-        function longRightClick(mouseButtonKey) {
+        function longClick(mouseButtonKey) {
+            longPress = true;
             switch (mouseButtonKey) {
                 case options.actionKey:
                     actionKeyDown = true;
@@ -1112,14 +1119,24 @@ var hoverZoom = {
             const mouseButtonKey = event.button[0,-2,-1,0,0];
             switch (mouseButtonKey) {
                 case options.actionKey:
-                    clearTimeout(longPressTimer); // clear timer if right click released too soon
+                    if (mouseButtonKey === -2){
+                        clearTimeout(longRightPressTimer);
+                    } else {
+                        clearTimeout(longMiddlePressTimer);
+                    }
                     if (actionKeyDown) {
                         actionKeyDown = false;
                         closeHoverZoomViewer();
                     }
                     break;
                 default:
-                    return;
+                    break;
+            }
+            if (imgFullSize) { 
+                switch (mouseButtonKey) {
+                    default:
+                        return;
+                }
             }
         }
 

--- a/js/hoverzoom.js
+++ b/js/hoverzoom.js
@@ -1084,6 +1084,77 @@ var hoverZoom = {
                 case options.toggleKey:
                     toggleKey()
                     return;
+                case options.fullZoomKey:
+                    if (!fullZoomKeyDown) {
+                        fullZoomKeyDown = true;
+                        posViewer();
+                        if (imgFullSize) {
+                            return false;
+                        }
+                    }
+                    return
+                case options.closeKey:
+                    viewerLocked = false;
+                    if (hz.hzViewer) {
+                        stopMedias();
+                        hz.hzViewer.hide();
+                    }
+                    if (imgFullSize) {
+                        return false;
+                    }
+                    return
+                case options.hideKey:
+                    if (!hideKeyDown) {
+                        hideKeyDown = true;
+                        if (hz.hzViewer) {
+                            pauseMedias();
+                            hz.hzViewer.hide();
+                        }
+                        if (imgFullSize) {
+                            return false;
+                        }
+                    }
+                    return
+                case options.copyImageKey:
+                    if (isChromiumBased) {
+                        if (keyCode === options.copyImageKey) {
+                            copyImage();
+                            return false;
+                        }
+                    }
+                    return false;
+                case options.copyImageUrlKey:
+                    copyLink();
+                    return false;
+                // "Previous image" key
+                case options.prevImgKey:
+                    var linkData = hz.currentLink.data();
+                    if (linkData.hoverZoomGallerySrc && linkData.hoverZoomGallerySrc.length > 1) rotateGalleryImg(-1);
+                    else changeVideoPosition(-parseInt(options.videoPositionStep));
+                    return false;
+                // "Next image" key
+                case options.nextImgKey:
+                    var linkData = hz.currentLink.data();
+                    if (linkData.hoverZoomGallerySrc && linkData.hoverZoomGallerySrc.length > 1) rotateGalleryImg(1);
+                    else changeVideoPosition(parseInt(options.videoPositionStep));
+                    return false;
+                // "Flip image" key
+                case options.flipImageKey:
+                    flipImage();
+                    return false;
+                case options.openImageInWindowKey:
+                    if (srcDetails.video) openVideoInWindow();
+                    else if (srcDetails.audio) openAudioInWindow();
+                    else openImageInWindow();
+                    return false;
+                case options.openImageInTabKey:
+                    if (srcDetails.video) openVideoInTab(event.shiftKey);
+                    else if (srcDetails.audio) openAudioInTab();
+                    else openImageInTab(event.shiftKey);
+                    return false;
+                case options.saveImageKey:
+                    saveImage();
+                    return false;
                 default:
                     return;
             }
@@ -1115,9 +1186,9 @@ var hoverZoom = {
             switch (mouseButtonKey) {
                 case options.actionKey:
                 case options.toggleKey:
-                //case options.fullZoomKey:
-                //case options.closeKey:
-                //case options.hideKey:
+                case options.fullZoomKey:
+                case options.closeKey:
+                case options.hideKey:
                     mouseButtonKeyHandler(mouseButtonKey, this);
                     return;
                 default:
@@ -1151,6 +1222,17 @@ var hoverZoom = {
                         closeHoverZoomViewer();
                     }
                     break;
+                case options.fullZoomKey:
+                    fullZoomKeyDown = false;
+                    $(this).mousemove();
+                    break;
+                case options.hideKey:
+                    hideKeyDown = false;
+                    if (imgFullSize) {
+                        hz.hzViewer.show();
+                        playMedias();
+                    }
+                    $(this).mousemove();
                 default:
                     if (imgFullSize) { 
                         switch (mouseButtonKey) {

--- a/js/hoverzoom.js
+++ b/js/hoverzoom.js
@@ -1091,15 +1091,15 @@ var hoverZoom = {
                             return false;
                         }
                     }
-                    return
+                    return;
                 case options.closeKey:
                     closeKey()
-                    return
+                    return;
                 case options.hideKey:
                     if (!hideKeyDown) {
                         hideKey()
                     }
-                    return
+                    return;
                 case options.copyImageKey:
                     if (isChromiumBased) {
                         if (keyCode === options.copyImageKey) {
@@ -1161,9 +1161,9 @@ var hoverZoom = {
                 }
                 cancelSourceLoading();
                 restoreTitles();
-                return
+                return;
             } else if (event.button === 0) { // We don't need left click
-                return
+                return;
             }
 
             // Gets mouse button key from event.button

--- a/js/hoverzoom.js
+++ b/js/hoverzoom.js
@@ -1050,20 +1050,20 @@ var hoverZoom = {
         let longMiddlePressTimer; // creates separate timer so they don't interfere
         let longPress = false;
         
-        function mouseButtonKeyHandler(mouseButtonKey){
+        function mouseButtonKeyHandler(mouseButtonKey) {
             const timerDelay = 150;
             if (mouseButtonKey === -2){
-                longRightPressTimer = setTimeout(longClick.bind(this), timerDelay, mouseButtonKey); // create a new timer for this click
+                longRightPressTimer = setTimeout(longClick.bind(this), timerDelay, mouseButtonKey);
             } else {
-                longPress = false;
-                longMiddlePressTimer = setTimeout(longClick.bind(this), timerDelay, mouseButtonKey); // create a new timer for this click
+                longMiddlePressTimer = setTimeout(longClick.bind(this), timerDelay, mouseButtonKey);
             }
         }
 
-        function clearMouseButtonTimers(mouseButtonKey){
-            if (mouseButtonKey === -2){
+        function clearMouseButtonTimers(mouseButtonKey) {
+            if (mouseButtonKey === -2) {
                 clearTimeout(longRightPressTimer);
             } else {
+                longPress = false;
                 clearTimeout(longMiddlePressTimer);
             }
         }
@@ -1087,7 +1087,7 @@ var hoverZoom = {
         }
 
         function documentContextMenu(event) {
-            // If it's been less than 300ms since right click, lock viewer and prevent context menu.
+            // If right click is a long press, prevent context menu
             if (longPress) {
                 longPress = false;
                 event.preventDefault();
@@ -1108,7 +1108,7 @@ var hoverZoom = {
             if (imgFullSize) { 
                 switch (mouseButtonKey) {
                     case options.lockImageKey:
-                        mouseButtonKeyHandler(mouseButtonKey).bind(this);
+                        mouseButtonKeyHandler(mouseButtonKey);
                         return;
                     default:
                         break;
@@ -1128,13 +1128,14 @@ var hoverZoom = {
             const mouseButtonKey = -event.button
             switch (mouseButtonKey) {
                 case options.actionKey:
-                    clearMouseButtonTimers;
+                    clearMouseButtonTimers(mouseButtonKey);
                     if (actionKeyDown) {
                         actionKeyDown = false;
                         closeHoverZoomViewer();
                     }
                     return;
                 default:
+                    clearMouseButtonTimers(mouseButtonKey);
                     break;
             }
             if (imgFullSize) { 

--- a/js/hoverzoom.js
+++ b/js/hoverzoom.js
@@ -1094,25 +1094,11 @@ var hoverZoom = {
                     }
                     return
                 case options.closeKey:
-                    viewerLocked = false;
-                    if (hz.hzViewer) {
-                        stopMedias();
-                        hz.hzViewer.hide();
-                    }
-                    if (imgFullSize) {
-                        return false;
-                    }
+                    closeKey()
                     return
                 case options.hideKey:
                     if (!hideKeyDown) {
-                        hideKeyDown = true;
-                        if (hz.hzViewer) {
-                            pauseMedias();
-                            hz.hzViewer.hide();
-                        }
-                        if (imgFullSize) {
-                            return false;
-                        }
+                        hideKey()
                     }
                     return
                 case options.copyImageKey:
@@ -2619,6 +2605,28 @@ var hoverZoom = {
             }
         }
 
+        function closeKey() {
+            viewerLocked = false;
+            if (hz.hzViewer) {
+                stopMedias();
+                hz.hzViewer.hide();
+            }
+            if (imgFullSize) {
+                return false;
+            }
+        }
+
+        function hideKey(){
+            hideKeyDown = true;
+            if (hz.hzViewer) {
+                pauseMedias();
+                hz.hzViewer.hide();
+            }
+            if (imgFullSize) {
+                return false;
+            }
+        }
+
         function documentOnKeyDown(event) {
             // Skips if an input controlled is focused
             if (event.target && ['INPUT','TEXTAREA','SELECT'].indexOf(event.target.tagName) > -1) {
@@ -2653,27 +2661,13 @@ var hoverZoom = {
             // close key (close zoomed image) is pressed down
             // => zoomed image is closed immediately
             if (keyCode === options.closeKey) {
-                viewerLocked = false;
-                if (hz.hzViewer) {
-                    stopMedias();
-                    hz.hzViewer.hide();
-                }
-                if (imgFullSize) {
-                    return false;
-                }
+                closeKey()
             }
 
             // hide key (hide zoomed image) is pressed down
             // => zoomed image remains hidden until key is released
             if (keyCode === options.hideKey && !hideKeyDown) {
-                hideKeyDown = true;
-                if (hz.hzViewer) {
-                    pauseMedias();
-                    hz.hzViewer.hide();
-                }
-                if (imgFullSize) {
-                    return false;
-                }
+                hideKey()
             }
 
             // the following keys are processed only if an image is displayed

--- a/js/hoverzoom.js
+++ b/js/hoverzoom.js
@@ -1233,13 +1233,8 @@ var hoverZoom = {
                         playMedias();
                     }
                     $(this).mousemove();
+                    break;
                 default:
-                    if (imgFullSize) { 
-                        switch (mouseButtonKey) {
-                            default:
-                                break;
-                        }
-                    }
                     break;
             }
             clearMouseButtonTimers(mouseButtonKey);

--- a/js/hoverzoom.js
+++ b/js/hoverzoom.js
@@ -1098,6 +1098,18 @@ var hoverZoom = {
         }
 
         function documentMouseDown(event) {
+            // if image is locked and left click is pressed outside of locked image
+            if (event.button === 0 && imgFullSize && event.target !== hz.hzViewer[0] && event.target !== imgFullSize[0]) {
+                if (viewerLocked) {
+                    viewerLocked = false;
+                }
+                cancelSourceLoading();
+                restoreTitles();
+                return
+            } else if (event.button === 0) { // We don't need left click
+                return
+            }
+
             // Gets mouse button key from event.button
             const mouseButtonKey = -event.button
             switch (mouseButtonKey) {
@@ -1106,40 +1118,33 @@ var hoverZoom = {
                 //case options.fullZoomKey:
                 //case options.closeKey:
                 //case options.hideKey:
-                        event.preventDefault();
                     mouseButtonKeyHandler(mouseButtonKey, this);
                     return;
                 default:
-                    break;
-            }
-            // The following only trigger when image is displayed
-            if (imgFullSize) { 
-                switch (mouseButtonKey) {
-                    case options.lockImageKey:
-                    case options.copyImageKey:
-                    case options.copyImageUrlKey:
-                    case options.flipImageKey:
-                    case options.openImageInWindowKey:
-                    case options.openImageInTabKey:
-                    case options.saveImageKey:
-                        mouseButtonKeyHandler(mouseButtonKey);
-                        return;
-                    default:
-                        break;
-                }
-                if (mouseButtonKey === 0 && event.target !== hz.hzViewer[0] && event.target !== imgFullSize[0]) {
-                    // if image is locked and left click is pressed outside of locked image
-                    if (viewerLocked) {
-                        viewerLocked = false;
+                    // The following only trigger when image is displayed
+                    if (imgFullSize) { 
+                        switch (mouseButtonKey) {
+                            case options.lockImageKey:
+                            case options.copyImageKey:
+                            case options.copyImageUrlKey:
+                            case options.flipImageKey:
+                            case options.openImageInWindowKey:
+                            case options.openImageInTabKey:
+                            case options.saveImageKey:
+                                mouseButtonKeyHandler(mouseButtonKey);
+                                return;
+                            default:
+                                break;
+                        }
                     }
-                    cancelSourceLoading();
-                    restoreTitles();
-                }
+                    return;
             }
         }
 
         function documentMouseUp(event) {
-            const mouseButtonKey = -event.button
+            if (event.button === 0) return; // If left click, return
+
+            const mouseButtonKey = -event.button;
             switch (mouseButtonKey) {
                 case options.actionKey:
                     if (actionKeyDown) {

--- a/js/hoverzoom.js
+++ b/js/hoverzoom.js
@@ -1056,7 +1056,7 @@ var hoverZoom = {
                 lockViewer();
                 event.preventDefault();
             }
-            if (options.actionKey === -1 && longPress) {
+            if (longPress) {
                 longPress = false;
                 event.preventDefault();
             }

--- a/js/hoverzoom.js
+++ b/js/hoverzoom.js
@@ -125,7 +125,7 @@ var hoverZoom = {
             arrowUpKeyDown = false,
             arrowDownKeyDown = false,
             viewerLocked = false,
-            lockViewerClickTime = 0,
+            viewerClickTime = 0,
             zoomFactor = 1,
             zoomSpeedFactor = 1,
             pageActionShown = false,
@@ -1051,7 +1051,7 @@ var hoverZoom = {
 
         function documentContextMenu(event) {
             // If it's been less than 300ms since right click, lock viewer and prevent context menu.
-            let lockElapsed = event.timeStamp - lockViewerClickTime;
+            let lockElapsed = event.timeStamp - viewerClickTime;
             if (imgFullSize && !viewerLocked && options.lockImageKey === -1 && lockElapsed < 300) {
                 lockViewer();
                 event.preventDefault();
@@ -1065,7 +1065,7 @@ var hoverZoom = {
             // Right click pressed and lockImageKey or actionKey is set to special value for right click (-1).
             if ((options.lockImageKey === -1 || options.actionKey === -1) && event.button === 2){
                 clearTimeout(longPress);                                       // clear any running timers
-                lockViewerClickTime = event.timeStamp;
+                viewerClickTime = event.timeStamp;
                 longPress = setTimeout(longRightClick.bind(this), pressDelay); // create a new timer for this click
                 
             } else if (imgFullSize && event.target !== hz.hzViewer[0] && event.target !== imgFullSize[0]) {

--- a/js/hoverzoom.js
+++ b/js/hoverzoom.js
@@ -125,7 +125,6 @@ var hoverZoom = {
             arrowUpKeyDown = false,
             arrowDownKeyDown = false,
             viewerLocked = false,
-            viewerClickTime = 0,
             zoomFactor = 1,
             zoomSpeedFactor = 1,
             pageActionShown = false,

--- a/js/options.js
+++ b/js/options.js
@@ -48,7 +48,7 @@ function initActionKeys() {
 function loadKeys(sel) {
     console.log(sel.attr('id'))
     $('<option value="0">None</option>').appendTo(sel);
-    if (sel.attr('id') == 'selLockImageKey')
+    if (sel.attr('id') == 'selLockImageKey' || sel.attr('id') == 'selActionKey')
         $('<option value="-1">Right Click</option>').appendTo(sel);
     if (sel.attr('id') != 'selOpenImageInTabKey')
         $('<option value="16">Shift</option>').appendTo(sel);

--- a/js/options.js
+++ b/js/options.js
@@ -47,7 +47,7 @@ function initActionKeys() {
 
 function loadKeys(sel) {
     console.log(sel.attr('id'))
-    $('<option value="0">None</option>').appendTo(sel);
+    $('<option value="-5">None</option>').appendTo(sel);
     if (sel.attr('id') == 'selLockImageKey' || sel.attr('id') == 'selActionKey')
         $('<option value="-2">Right Click</option>').appendTo(sel);
     if (sel.attr('id') != 'selOpenImageInTabKey')

--- a/js/options.js
+++ b/js/options.js
@@ -48,8 +48,8 @@ function initActionKeys() {
 function loadKeys(sel) {
     $('<option value="-5">None</option>').appendTo(sel);
     if (sel.attr('id') != 'selPrevImgKey' || sel.attr('id') != 'selNextImgKey'){
-        $('<option value="-2">Right Click</option>').appendTo(sel);
-        $('<option value="-1">Middle Click</option>').appendTo(sel);
+        $('<option value="-1">Right Click</option>').appendTo(sel);
+        $('<option value="-2">Middle Click</option>').appendTo(sel);
     }
     if (sel.attr('id') != 'selOpenImageInTabKey')
         $('<option value="16">Shift</option>').appendTo(sel);
@@ -363,7 +363,7 @@ function btnRemoveExcludedSiteOnClick() {
 }
 
 function selKeyOnChange(event) {
-    let noneKey = '-5'; // sel key code for 'none'
+    let noneKey = '0'; // sel key code for 'none'
     let currSel = $(event.target);
     if (currSel[0].dataset.val0 == undefined) return; // event fired before init
     currSel[0].dataset.val1 = currSel.val();

--- a/js/options.js
+++ b/js/options.js
@@ -46,7 +46,7 @@ function initActionKeys() {
 }
 
 function loadKeys(sel) {
-    $('<option value="-5">None</option>').appendTo(sel);
+    $('<option value="0">None</option>').appendTo(sel);
     if (sel.attr('id') != 'selPrevImgKey' || sel.attr('id') != 'selNextImgKey'){
         $('<option value="-1">Right Click</option>').appendTo(sel);
         $('<option value="-2">Middle Click</option>').appendTo(sel);

--- a/js/options.js
+++ b/js/options.js
@@ -49,7 +49,7 @@ function loadKeys(sel) {
     console.log(sel.attr('id'))
     $('<option value="0">None</option>').appendTo(sel);
     if (sel.attr('id') == 'selLockImageKey' || sel.attr('id') == 'selActionKey')
-        $('<option value="-1">Right Click</option>').appendTo(sel);
+        $('<option value="-2">Right Click</option>').appendTo(sel);
     if (sel.attr('id') != 'selOpenImageInTabKey')
         $('<option value="16">Shift</option>').appendTo(sel);
     $('<option value="17">Ctrl</option>').appendTo(sel);

--- a/js/options.js
+++ b/js/options.js
@@ -46,8 +46,9 @@ function initActionKeys() {
 }
 
 function loadKeys(sel) {
+    console.log(sel.attr('id'))
     $('<option value="0">None</option>').appendTo(sel);
-    if (sel.attr('id') != 'lockImageKey')
+    if (sel.attr('id') == 'selLockImageKey')
         $('<option value="-1">Right Click</option>').appendTo(sel);
     if (sel.attr('id') != 'selOpenImageInTabKey')
         $('<option value="16">Shift</option>').appendTo(sel);

--- a/js/options.js
+++ b/js/options.js
@@ -363,7 +363,7 @@ function btnRemoveExcludedSiteOnClick() {
 }
 
 function selKeyOnChange(event) {
-    let noneKey = '0'; // sel key code for 'none'
+    const noneKey = '0'; // sel key code for 'none'
     let currSel = $(event.target);
     if (currSel[0].dataset.val0 == undefined) return; // event fired before init
     currSel[0].dataset.val1 = currSel.val();

--- a/js/options.js
+++ b/js/options.js
@@ -48,8 +48,10 @@ function initActionKeys() {
 function loadKeys(sel) {
     console.log(sel.attr('id'))
     $('<option value="-5">None</option>').appendTo(sel);
-    if (sel.attr('id') == 'selLockImageKey' || sel.attr('id') == 'selActionKey')
+    if (sel.attr('id') == 'selLockImageKey' || sel.attr('id') == 'selActionKey'){
         $('<option value="-2">Right Click</option>').appendTo(sel);
+        $('<option value="-1">Middle Click</option>').appendTo(sel);
+    }
     if (sel.attr('id') != 'selOpenImageInTabKey')
         $('<option value="16">Shift</option>').appendTo(sel);
     $('<option value="17">Ctrl</option>').appendTo(sel);

--- a/js/options.js
+++ b/js/options.js
@@ -48,7 +48,7 @@ function initActionKeys() {
 function loadKeys(sel) {
     console.log(sel.attr('id'))
     $('<option value="-5">None</option>').appendTo(sel);
-    if (sel.attr('id') == 'selLockImageKey' || sel.attr('id') == 'selActionKey'){
+    if (sel.attr('id') != 'selPrevImgKey' || sel.attr('id') != 'selNextImgKey'){
         $('<option value="-2">Right Click</option>').appendTo(sel);
         $('<option value="-1">Middle Click</option>').appendTo(sel);
     }

--- a/js/options.js
+++ b/js/options.js
@@ -46,7 +46,6 @@ function initActionKeys() {
 }
 
 function loadKeys(sel) {
-    console.log(sel.attr('id'))
     $('<option value="-5">None</option>').appendTo(sel);
     if (sel.attr('id') != 'selPrevImgKey' || sel.attr('id') != 'selNextImgKey'){
         $('<option value="-2">Right Click</option>').appendTo(sel);
@@ -364,14 +363,15 @@ function btnRemoveExcludedSiteOnClick() {
 }
 
 function selKeyOnChange(event) {
-    var currSel = $(event.target);
+    let noneKey = '-5'; // sel key code for 'none'
+    let currSel = $(event.target);
     if (currSel[0].dataset.val0 == undefined) return; // event fired before init
     currSel[0].dataset.val1 = currSel.val();
     checkModification(currSel);
-    if (currSel.val() != '0') {
+    if (currSel.val() != noneKey) {
         $('.actionKey').each(function () {
             if (!$(this).is(currSel) && $(this).val() == currSel.val()) {
-                $(this).val('0');
+                $(this).val(noneKey);
                 $(this)[0].dataset.val1 = $(this).val();
                 checkModification($(this));
             }

--- a/js/popup.js
+++ b/js/popup.js
@@ -39,7 +39,7 @@ function initActionKeys() {
 }
 
 function loadKeys(sel) {
-    $('<option value="-5">None</option>').appendTo(sel);
+    $('<option value="0">None</option>').appendTo(sel);
     if (sel.attr('id') != 'selPrevImgKey' || sel.attr('id') != 'selNextImgKey'){
         $('<option value="-1">Right Click</option>').appendTo(sel);
         $('<option value="-2">Middle Click</option>').appendTo(sel);

--- a/js/popup.js
+++ b/js/popup.js
@@ -40,7 +40,7 @@ function initActionKeys() {
 
 function loadKeys(sel) {
     $('<option value="0">None</option>').appendTo(sel);
-    if (sel.attr('id') == 'selLockImageKey')
+    if (sel.attr('id') == 'selLockImageKey' || sel.attr('id') == 'selActionKey')
         $('<option value="-1">Right Click</option>').appendTo(sel);
     if (sel.attr('id') != 'selOpenImageInTabKey')
         $('<option value="16">Shift</option>').appendTo(sel);

--- a/js/popup.js
+++ b/js/popup.js
@@ -40,7 +40,7 @@ function initActionKeys() {
 
 function loadKeys(sel) {
     $('<option value="-5">None</option>').appendTo(sel);
-    if (sel.attr('id') == 'selLockImageKey' || sel.attr('id') == 'selActionKey'){
+    if (sel.attr('id') != 'selPrevImgKey' || sel.attr('id') != 'selNextImgKey'){
         $('<option value="-2">Right Click</option>').appendTo(sel);
         $('<option value="-1">Middle Click</option>').appendTo(sel);
     }

--- a/js/popup.js
+++ b/js/popup.js
@@ -159,7 +159,7 @@ function restoreOptions(optionsFromFactorySettings) {
 }
 
 function selKeyOnChange(event) {
-    let noneKey = '0'; // sel key code for 'none'
+    const noneKey = '0'; // sel key code for 'none'
     let currSel = $(event.target);
     if (currSel[0].dataset.val0 == undefined) return; // event fired before init
     currSel[0].dataset.val1 = currSel.val();

--- a/js/popup.js
+++ b/js/popup.js
@@ -39,7 +39,7 @@ function initActionKeys() {
 }
 
 function loadKeys(sel) {
-    $('<option value="0">None</option>').appendTo(sel);
+    $('<option value="-5">None</option>').appendTo(sel);
     if (sel.attr('id') == 'selLockImageKey' || sel.attr('id') == 'selActionKey')
         $('<option value="-2">Right Click</option>').appendTo(sel);
     if (sel.attr('id') != 'selOpenImageInTabKey')

--- a/js/popup.js
+++ b/js/popup.js
@@ -41,7 +41,7 @@ function initActionKeys() {
 function loadKeys(sel) {
     $('<option value="0">None</option>').appendTo(sel);
     if (sel.attr('id') == 'selLockImageKey' || sel.attr('id') == 'selActionKey')
-        $('<option value="-1">Right Click</option>').appendTo(sel);
+        $('<option value="-2">Right Click</option>').appendTo(sel);
     if (sel.attr('id') != 'selOpenImageInTabKey')
         $('<option value="16">Shift</option>').appendTo(sel);
     $('<option value="17">Ctrl</option>').appendTo(sel);

--- a/js/popup.js
+++ b/js/popup.js
@@ -40,7 +40,7 @@ function initActionKeys() {
 
 function loadKeys(sel) {
     $('<option value="0">None</option>').appendTo(sel);
-    if (sel.attr('id') != 'lockImageKey')
+    if (sel.attr('id') == 'selLockImageKey')
         $('<option value="-1">Right Click</option>').appendTo(sel);
     if (sel.attr('id') != 'selOpenImageInTabKey')
         $('<option value="16">Shift</option>').appendTo(sel);

--- a/js/popup.js
+++ b/js/popup.js
@@ -40,8 +40,10 @@ function initActionKeys() {
 
 function loadKeys(sel) {
     $('<option value="-5">None</option>').appendTo(sel);
-    if (sel.attr('id') == 'selLockImageKey' || sel.attr('id') == 'selActionKey')
+    if (sel.attr('id') == 'selLockImageKey' || sel.attr('id') == 'selActionKey'){
         $('<option value="-2">Right Click</option>').appendTo(sel);
+        $('<option value="-1">Middle Click</option>').appendTo(sel);
+    }
     if (sel.attr('id') != 'selOpenImageInTabKey')
         $('<option value="16">Shift</option>').appendTo(sel);
     $('<option value="17">Ctrl</option>').appendTo(sel);

--- a/js/popup.js
+++ b/js/popup.js
@@ -159,14 +159,15 @@ function restoreOptions(optionsFromFactorySettings) {
 }
 
 function selKeyOnChange(event) {
-    var currSel = $(event.target);
+    let noneKey = '-5'; // sel key code for 'none'
+    let currSel = $(event.target);
     if (currSel[0].dataset.val0 == undefined) return; // event fired before init
     currSel[0].dataset.val1 = currSel.val();
     checkModification(currSel);
-    if (currSel.val() != '0') {
+    if (currSel.val() != noneKey) {
         $('.actionKey').each(function () {
             if (!$(this).is(currSel) && $(this).val() == currSel.val()) {
-                $(this).val('0');
+                $(this).val(noneKey);
                 $(this)[0].dataset.val1 = $(this).val();
                 checkModification($(this));
             }

--- a/js/popup.js
+++ b/js/popup.js
@@ -41,8 +41,8 @@ function initActionKeys() {
 function loadKeys(sel) {
     $('<option value="-5">None</option>').appendTo(sel);
     if (sel.attr('id') != 'selPrevImgKey' || sel.attr('id') != 'selNextImgKey'){
-        $('<option value="-2">Right Click</option>').appendTo(sel);
-        $('<option value="-1">Middle Click</option>').appendTo(sel);
+        $('<option value="-1">Right Click</option>').appendTo(sel);
+        $('<option value="-2">Middle Click</option>').appendTo(sel);
     }
     if (sel.attr('id') != 'selOpenImageInTabKey')
         $('<option value="16">Shift</option>').appendTo(sel);
@@ -159,7 +159,7 @@ function restoreOptions(optionsFromFactorySettings) {
 }
 
 function selKeyOnChange(event) {
-    let noneKey = '-5'; // sel key code for 'none'
+    let noneKey = '0'; // sel key code for 'none'
     let currSel = $(event.target);
     if (currSel[0].dataset.val0 == undefined) return; // event fired before init
     currSel[0].dataset.val1 = currSel.val();


### PR DESCRIPTION
Fully adds right click and middle click as an action key. Before, right key was showing as an action key but was only being handled for 'lockImage'. This updates it so right click and middle click are completely useable as a key.

### Caveats and Issues I couldn't figure out:
- Middle click still does it's normal function, even after HZ+ function triggers. Right click doesn't
    - event.preventDefault() wasn't working to fix the issue, even after trying many things with it. 
- The hold delay is set to 150ms. It felt short enough to not wait, but it was long enough to not trigger accidentally
- Some buttons that don't require an image to be shown might trigger accidentally with normal use. E.g. toggle HZ+ when it's set to middle mouse click.
- The performance hit shouldn't be noticeable as a switch case is used to handle mouse events, but it is still triggered with every right and middle mouse click, even when they aren't selected for any action key.