### PR TITLE
Fix middle click's timer affecting right click's context menu

### DIFF
--- a/js/hoverzoom.js
+++ b/js/hoverzoom.js
@@ -1059,7 +1059,7 @@ var hoverZoom = {
 
         let longRightPressTimer; // create timer
         let longMiddlePressTimer; // creates separate timer so they don't interfere
-        let longPress = false;
+        let longRightPress = false;
         
         function mouseButtonKeyHandler(mouseButtonKey, img) {
             const timerDelay = 150;
@@ -1074,14 +1074,15 @@ var hoverZoom = {
             if (mouseButtonKey === -1) {
                 clearTimeout(longRightPressTimer);
             } else {
-                longPress = false;
                 clearTimeout(longMiddlePressTimer);
             }
         }
         
         function longClick(mouseButtonKey) {
-            longPress = true;
             switch (mouseButtonKey) {
+                case -1:
+                    longRightPress = true;
+                    break
                 case options.actionKey:
                     actionKeyDown = true;
                     $(this).mousemove();
@@ -1159,8 +1160,8 @@ var hoverZoom = {
 
         function documentContextMenu(event) {
             // If right click is a long press, prevent context menu
-            if (longPress) {
-                longPress = false;
+            if (longRightPress) {
+                longRightPress = false;
                 event.preventDefault();
             }
         }

--- a/js/hoverzoom.js
+++ b/js/hoverzoom.js
@@ -1079,10 +1079,8 @@ var hoverZoom = {
         }
         
         function longClick(mouseButtonKey) {
+            if (mouseButtonKey == -1) longRightPress = true;
             switch (mouseButtonKey) {
-                case -1:
-                    longRightPress = true;
-                    break
                 case options.actionKey:
                     actionKeyDown = true;
                     $(this).mousemove();


### PR DESCRIPTION
Pressing middle click as an action key would cause right click to not have a context menu, if pressed while middle clicked was held.