### PR TITLE
Fix slickdeals plugin

### DIFF
--- a/plugins/slickdeals.js
+++ b/plugins/slickdeals.js
@@ -1,7 +1,7 @@
 ﻿var hoverZoomPlugins = hoverZoomPlugins || [];
 hoverZoomPlugins.push({
     name:'slickdeals',
-    version:'0.2',
+    version:'0.3',
     prepareImgLinks:function (callback) {
         var res = [];
 
@@ -19,7 +19,7 @@ hoverZoomPlugins.push({
             hoverZoom.displayPicFromElement(img);
         });
 
-        $('body').on('mouseenter', 'span.dealCardList__dealImageContainer, a.bp-c-card_imageContainer', function() {
+        $('body').on('mouseenter', 'span.dealCardList__dealImageContainer, a.bp-c-card_imageContainer, figure.dealImage', function() {
             const self = $(this);
             const img = self.find('img');
             if (img.length === 1) {


### PR DESCRIPTION
This updates it to work with changes to the site. It's also backwards compatible, and won't affect places the plugin is currently working.