### PR TITLE
Fix for plugin: kleinanzeigen.de (#1471)

### DIFF
--- a/plugins/kleinanzeigen.js
+++ b/plugins/kleinanzeigen.js
@@ -1,23 +1,51 @@
 var hoverZoomPlugins = hoverZoomPlugins || [];
 hoverZoomPlugins.push({
     name:'kleinanzeigen.de',
-    version:'0.1',
+    version:'0.2',
     prepareImgLinks:function (callback) {
+        var pluginName = this.name;
         var res = [];
-        $('.aditem-image img').each(function () {
-            var elem = $(this);
 
-            var url = elem.attr('src') || hoverZoom.getThumbUrl(this);
-            url = url.replace(/rule=\$_.+.JPG/, 'rule=$_59.JPG');
+        // load img gallery, e.g: https://www.kleinanzeigen.de/s-anzeige/esstisch-massive-eiche/2942601447-86-1757
+        function loadGallery(link, href) {
 
-            var target = elem.parents('a');
-            if (target.length > 0) elem = $(target[0]);
+            chrome.runtime.sendMessage({action:'ajaxGet', url:href}, function (response) {
 
-            elem.data().hoverZoomSrc = [url];
-            res.push(elem);
+                if (response == null) { return; }
+
+                const parser = new DOMParser();
+                const doc = $(parser.parseFromString(response, "text/html"));
+
+                const metas = doc.find('div[data-ix] meta[itemProp*="contentUrl"]');
+                const titles = doc.find('div[data-ix] img[title]');
+                if (metas.length == 0) return;
+                var gallery = [];
+                metas.each(i => gallery.push([metas[i].content]));
+                var captions = [];
+                if (gallery.length == titles.length) {
+                    titles.each(i => captions.push(titles[i].title));
+                }
+
+                link.data().hoverZoomGallerySrc = gallery;
+                link.data().hoverZoomGalleryCaption = captions;
+                callback(link, pluginName);
+                // Gallery is displayed iff cursor is still over the gallery
+                if (link.data().hoverZoomMouseOver)
+                    hoverZoom.displayPicFromElement(link);
+            });
+        }
+
+        $('a[href*="/s-anzeige/"]').one('mouseover', function() {
+            const link = $(this);
+            if (link.data().hoverZoomMouseOver) return;
+            link.data().hoverZoomMouseOver = true;
+            const href = this.href;
+            loadGallery(link, href);
+
+        }).one('mouseleave', function() {
+            const link = $(this);
+            link.data().hoverZoomMouseOver = false;
         });
-
-        
 
         callback($(res), this.name);
     }


### PR DESCRIPTION
Image galleries are now correctly displayed.

![image](https://github.com/user-attachments/assets/719bf78a-ce96-420f-abc4-8522587ca329)
