### PR TITLE
New action key: ban an image, video or audio track

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -747,6 +747,18 @@
         "message": "On save, replace original filename by:",
         "description": "[options] Replace original filename when downloading option"
     },
+    "optResetAllBannedImagesTooltip": {
+    	"message": "After reset, all banned images, videos & audio tracks can be zoomed again",
+    	"description": "[options] Tooltip for reset all banned images option"
+    },
+    "optResetAllBannedImages": {
+    	"message": "Reset all banned images, videos & audio tracks",
+    	"description": "[options] Reset all banned images option"
+    },
+    "optButtonResetAllBannedImages": {
+    	"message": "Reset",
+    	"description": "[options] Reset all banned images button"
+    },
     "optSectionTroubleshooting": {
         "message": "Troubleshooting",
         "description": "[options] Page section for troubleshooting"
@@ -941,6 +953,14 @@
     },
     "optHideKeyDescription": {
         "message": "Holding this key down hides the zoomed image or video. Use it when the picture hides elements that are also displayed on mouseover.",
+    	"description": "[options] Action key description"
+    },
+    "optBanKeyTitle": {
+    	"message": "Ban image",
+    	"description": "[options] Action key title"
+    },
+    "optBanKeyDescription": {
+    	"message": "Holding this key down adds the zoomed image or video to ban list. Use it when you do not want an image or video to be zoomed again on this page.",
         "description": "[options] Action key description"
     },
     "optOpenImageInWindowKeyTitle": {

--- a/css/style.css
+++ b/css/style.css
@@ -92,10 +92,11 @@ body.popup.darkmode { background-color: #101010F0; } /* dark grey */
 .popup.darkmode table tr:nth-child(even) { background-color: #DCB200F0; } /* yellow */
 .popup table tr:nth-child(odd) { background-color: #85B7E740; } /* light blue */
 .popup.darkmode table tr:nth-child(odd) { background-color: #0360B9F0; } /* blue */
-.popup table tr td { font-size: 12px; padding-left: 5px; padding-right: 5px; padding-top: 1px; padding-bottom: 1px; border-top: 0px; color: #202020F0; }
+.popup table tr td { font-size: 10px; padding-left: 5px; padding-right: 5px; padding-top: 0px; padding-bottom: 0px; border: 0px; color: #202020F0; }
 .popup table tr td.ttip { padding-right: 30px; }
 
-.popup .picker { height: auto; padding-right: 5px; }
+
+.popup .picker { height: auto; padding: 0px; font-size: 10px; margin: 0px; }
 .popup.darkmode .picker { background-image: linear-gradient(#606060F0, #101010F0); color: #F0F0F0F0; background-color: #101010F0; }
 
 .popup .tab-content, .popup .checkbox { padding-left: 10px; padding-right: 10px; padding-top: 0px; padding-bottom: 0px; }

--- a/html/options.html
+++ b/html/options.html
@@ -649,6 +649,12 @@
                                         <input class="normal text input" type="text" id="txtDownloadReplaceOriginalFilename" data-i18n-placeholder="optDownloadReplaceOriginalFilenamePlaceholder">
                                     </li>
                                 </div>
+                                <div class="ttip" data-i18n-tooltip="optResetAllBannedImagesTooltip">
+                                    <li class="field" style="display:flex">
+                                        <div data-i18n="optResetAllBannedImages" style="padding-right:10px"></div>
+                                        <div class="btn default"><a id="btnResetAllBannedImages" data-i18n="optButtonResetAllBannedImages"></a></div> 
+                                    </li>
+                                </div>
                             </ul>
                         </fieldset>
                         <fieldset>

--- a/js/common.js
+++ b/js/common.js
@@ -84,6 +84,7 @@ var factorySettings = {
     copyImageKey: 67,
     copyImageUrlKey: 85,
     hideKey : 88,
+    banKey : 66,
     openImageInWindowKey : 87,
     openImageInTabKey : 84,
     lockImageKey : 76,
@@ -205,6 +206,7 @@ function loadOptions() {
     options.copyImageKey = options.hasOwnProperty('copyImageKey') ? options.copyImageKey : factorySettings.copyImageKey;
     options.copyImageUrlKey = options.hasOwnProperty('copyImageUrlKey') ? options.copyImageUrlKey : factorySettings.copyImageUrlKey;
     options.hideKey = options.hasOwnProperty('hideKey') ? options.hideKey : factorySettings.hideKey;
+    options.banKey = options.hasOwnProperty('banKey') ? options.banKey : factorySettings.banKey;
     options.openImageInWindowKey = options.hasOwnProperty('openImageInWindowKey') ? options.openImageInWindowKey : factorySettings.openImageInWindowKey;
     options.openImageInTabKey = options.hasOwnProperty('openImageInTabKey') ? options.openImageInTabKey : factorySettings.openImageInTabKey;
     options.lockImageKey = options.hasOwnProperty('lockImageKey') ? options.lockImageKey : factorySettings.lockImageKey;

--- a/js/options.js
+++ b/js/options.js
@@ -2,7 +2,7 @@ var options,
     hoverZoomPlugins = hoverZoomPlugins || [],
     VK_CTRL = 1024,
     VK_SHIFT = 2048,
-    actionKeys = ['actionKey', 'toggleKey', 'closeKey', 'hideKey', 'openImageInWindowKey', 'openImageInTabKey', 'lockImageKey', 'saveImageKey', 'fullZoomKey', 'prevImgKey', 'nextImgKey', 'flipImageKey', 'copyImageKey', 'copyImageUrlKey'];
+    actionKeys = ['actionKey', 'toggleKey', 'closeKey', 'hideKey', 'banKey', 'openImageInWindowKey', 'openImageInTabKey', 'lockImageKey', 'saveImageKey', 'fullZoomKey', 'prevImgKey', 'nextImgKey', 'flipImageKey', 'copyImageKey', 'copyImageUrlKey'];
 
 function getMilliseconds(ctrl) {
     var value = parseFloat(ctrl.val());
@@ -578,6 +578,11 @@ function replaceOriginalFilenameOnChange(val) {
     return this.value;
 }
 
+function btnResetAllBannedImagesOnClick() {
+    const request = {action:'resetBannedImages'};
+    chrome.runtime.sendMessage(request);
+}
+
 function updateDivAmbilight() {
     if ($('#chkAmbilightEnabled')[0].checked) {
         $('#divAmbilight').removeClass('disabled');
@@ -844,6 +849,7 @@ $(function () {
     $('#txtDownloadFolder').change(downloadFolderOnChange);
     $('#chkDownloadReplaceOriginalFilename').parent().on('gumby.onChange', updateDownloadReplaceOriginalFilename);
     $('#txtDownloadReplaceOriginalFilename').change(replaceOriginalFilenameOnChange);
+    $('#btnResetAllBannedImages').click(btnResetAllBannedImagesOnClick);
     $('#chkUseSeparateTabOrWindowForUnloadableUrlsEnabled').parent().on('gumby.onChange', updateUseSeparateTabOrWindowForUnloadableUrls);
     $('#chkHideMouseCursor').parent().on('gumby.onChange', updateDivHideMouseCursor);
     $('#chkDarkMode').parent().on('gumby.onChange', updateDarkMode);

--- a/js/popup.js
+++ b/js/popup.js
@@ -3,7 +3,7 @@ var options,
     prgPreloading, lblPreloading, aPreload,
     VK_CTRL = 1024,
     VK_SHIFT = 2048,
-    actionKeys = ['actionKey', 'toggleKey', 'closeKey', 'hideKey', 'openImageInWindowKey', 'openImageInTabKey', 'lockImageKey', 'saveImageKey', 'fullZoomKey', 'prevImgKey', 'nextImgKey', 'flipImageKey', 'copyImageKey', 'copyImageUrlKey'];
+    actionKeys = ['actionKey', 'toggleKey', 'closeKey', 'hideKey', 'banKey', 'openImageInWindowKey', 'openImageInTabKey', 'lockImageKey', 'saveImageKey', 'fullZoomKey', 'prevImgKey', 'nextImgKey', 'flipImageKey', 'copyImageKey', 'copyImageUrlKey'];
 
 function keyCodeToString(key) {
     var s = '';


### PR DESCRIPTION
A new action key (default value: "B") can be used to prevent an image, video or audio track from being zoomed (and played) next time it is hovered. 

![image](https://github.com/user-attachments/assets/2a1f54c6-ba58-48a1-aa38-6159d624c2d1)


Ban is not lifted by just restarting browser. So in Advanced options, a new button is available in order to reset banned items so they can be zoomed again.

![image](https://github.com/user-attachments/assets/7615f274-7cb7-4881-afea-2cea862f7ba2)
