### PR TITLE
Fix: loadFullSizeImageImageTimeout not clearing when mouse leaves image

### DIFF
--- a/js/hoverzoom.js
+++ b/js/hoverzoom.js
@@ -1072,8 +1072,8 @@ var hoverZoom = {
                             const delay = actionKeyDown || explicitCall ? 0 : (isVideoLink(srcDetails.url) ? options.displayDelayVideo : options.displayDelay);
                             loadFullSizeImageTimeout = setTimeout(loadFullSizeImage, delay);
                             
-                            /** Temporarily removing until a better fix is found
-                            if (audioSrc) {
+                             // Temporarily removing until a better fix is found
+                            /*if (audioSrc) {
                                 chrome.runtime.sendMessage({action:'isImageBanned', url:audioSrc}, function (result) {
                                     if (!result) {
                                         loadFullSizeImageTimeout = setTimeout(loadFullSizeImage, delay);
@@ -1085,8 +1085,8 @@ var hoverZoom = {
                                         loadFullSizeImageTimeout = setTimeout(loadFullSizeImage, delay);
                                     }
                                 });                               
-                            }
-                            */
+                            }*/
+
                             loading = true;
                         }
                     } else {

--- a/js/hoverzoom.js
+++ b/js/hoverzoom.js
@@ -1072,7 +1072,7 @@ var hoverZoom = {
                             const delay = actionKeyDown || explicitCall ? 0 : (isVideoLink(srcDetails.url) ? options.displayDelayVideo : options.displayDelay);
                             loadFullSizeImageTimeout = setTimeout(loadFullSizeImage, delay);
                             
-                             // Temporarily removing until a better fix is found
+                            // Temporarily removing until a better fix is found: sendMessage is async so it can't be used to set local variables
                             /*if (audioSrc) {
                                 chrome.runtime.sendMessage({action:'isImageBanned', url:audioSrc}, function (result) {
                                     if (!result) {

--- a/js/hoverzoom.js
+++ b/js/hoverzoom.js
@@ -1073,7 +1073,7 @@ var hoverZoom = {
                             srcDetails.audioUrl = audioSrc;
                             clearTimeout(loadFullSizeImageTimeout);
                             
-                            // setLoadImage used to set loadHoveredImage within callack so timeout can be set outside of callback
+                            // setLoadImage used to set loadHoveredImage within callback so timeout can be set outside of callback
                             // This makes clearTimeout use the correct timeout ID
                             if (audioSrc) {
                                 chrome.runtime.sendMessage({action:'isImageBanned', url:audioSrc}, function (result) {

--- a/js/hoverzoom.js
+++ b/js/hoverzoom.js
@@ -981,11 +981,6 @@ var hoverZoom = {
         }
 
         var lastMousePosTop = -1, lastMousePosLeft = -1, cursorHideTimeout = 0;
-        let loadHoveredImage = false;
-        
-        function setLoadImage(load) {
-            loadHoveredImage = load;
-        }
 
         function documentMouseMove(event) {
             if (!options.extensionEnabled || fullZoomKeyDown || isExcludedSite() || wnd.height() < 30 || wnd.width() < 30) {
@@ -1072,28 +1067,25 @@ var hoverZoom = {
                             srcDetails.url = src;
                             srcDetails.audioUrl = audioSrc;
                             clearTimeout(loadFullSizeImageTimeout);
+
+                            // if the action key has been pressed over an image, no delay is applied
+                            const delay = actionKeyDown || explicitCall ? 0 : (isVideoLink(srcDetails.url) ? options.displayDelayVideo : options.displayDelay);
                             
                             // setLoadImage used to set loadHoveredImage within callback so timeout can be set outside of callback
                             // This makes clearTimeout use the correct timeout ID
                             if (audioSrc) {
                                 chrome.runtime.sendMessage({action:'isImageBanned', url:audioSrc}, function (result) {
-                                    setLoadImage(false);
                                     if (!result) {
-                                        setLoadImage(true);
+                                        loadFullSizeImageTimeout = setTimeout(loadFullSizeImage, delay);
                                     }
                                 });
                             } else if (src) {
                                 chrome.runtime.sendMessage({action:'isImageBanned', url:src}, function (result) {
-                                    setLoadImage(false);
                                     if (!result) {
-                                        setLoadImage(true);
+                                        loadFullSizeImageTimeout = setTimeout(loadFullSizeImage, delay);
                                     }
                                 });                               
                             }
-                            
-                            // if the action key has been pressed over an image, no delay is applied
-                            const delay = actionKeyDown || explicitCall ? 0 : (isVideoLink(srcDetails.url) ? options.displayDelayVideo : options.displayDelay);
-                            if (loadHoveredImage) loadFullSizeImageTimeout = setTimeout(loadFullSizeImage, delay);
 
                             loading = true;
                         }

--- a/js/hoverzoom.js
+++ b/js/hoverzoom.js
@@ -981,6 +981,11 @@ var hoverZoom = {
         }
 
         var lastMousePosTop = -1, lastMousePosLeft = -1, cursorHideTimeout = 0;
+        let loadHoveredImage = false;
+        
+        function setLoadImage(load) {
+            loadHoveredImage = load;
+        }
 
         function documentMouseMove(event) {
             if (!options.extensionEnabled || fullZoomKeyDown || isExcludedSite() || wnd.height() < 30 || wnd.width() < 30) {
@@ -1067,23 +1072,26 @@ var hoverZoom = {
                             srcDetails.url = src;
                             srcDetails.audioUrl = audioSrc;
                             clearTimeout(loadFullSizeImageTimeout);
-
-                            // if the action key has been pressed over an image, no delay is applied
-                            const delay = actionKeyDown || explicitCall ? 0 : (isVideoLink(srcDetails.url) ? options.displayDelayVideo : options.displayDelay);
                             
                             if (audioSrc) {
                                 chrome.runtime.sendMessage({action:'isImageBanned', url:audioSrc}, function (result) {
+                                    setLoadImage(false);
                                     if (!result) {
-                                        loadFullSizeImageTimeout = setTimeout(loadFullSizeImage, delay);
+                                        setLoadImage(true);
                                     }
                                 });
                             } else if (src) {
                                 chrome.runtime.sendMessage({action:'isImageBanned', url:src}, function (result) {
+                                    setLoadImage(false);
                                     if (!result) {
-                                        loadFullSizeImageTimeout = setTimeout(loadFullSizeImage, delay);
+                                        setLoadImage(true);
                                     }
                                 });                               
                             }
+                            
+                            // if the action key has been pressed over an image, no delay is applied
+                            const delay = actionKeyDown || explicitCall ? 0 : (isVideoLink(srcDetails.url) ? options.displayDelayVideo : options.displayDelay);
+                            if (loadHoveredImage) loadFullSizeImageTimeout = setTimeout(loadFullSizeImage, delay);
 
                             loading = true;
                         }

--- a/js/hoverzoom.js
+++ b/js/hoverzoom.js
@@ -1070,6 +1070,7 @@ var hoverZoom = {
 
                             // if the action key has been pressed over an image, no delay is applied
                             const delay = actionKeyDown || explicitCall ? 0 : (isVideoLink(srcDetails.url) ? options.displayDelayVideo : options.displayDelay);
+                            loadFullSizeImageTimeout = setTimeout(loadFullSizeImage, delay);
                             
                             /** Temporarily removing until a better fix is found
                             if (audioSrc) {

--- a/js/hoverzoom.js
+++ b/js/hoverzoom.js
@@ -1073,6 +1073,8 @@ var hoverZoom = {
                             srcDetails.audioUrl = audioSrc;
                             clearTimeout(loadFullSizeImageTimeout);
                             
+                            // setLoadImage used to set loadHoveredImage within callack so timeout can be set outside of callback
+                            // This makes clearTimeout use the correct timeout ID
                             if (audioSrc) {
                                 chrome.runtime.sendMessage({action:'isImageBanned', url:audioSrc}, function (result) {
                                     setLoadImage(false);

--- a/js/hoverzoom.js
+++ b/js/hoverzoom.js
@@ -1071,8 +1071,7 @@ var hoverZoom = {
                             // if the action key has been pressed over an image, no delay is applied
                             const delay = actionKeyDown || explicitCall ? 0 : (isVideoLink(srcDetails.url) ? options.displayDelayVideo : options.displayDelay);
                             
-                            // setLoadImage used to set loadHoveredImage within callback so timeout can be set outside of callback
-                            // This makes clearTimeout use the correct timeout ID
+                            /** Temporarily removing until a better fix is found
                             if (audioSrc) {
                                 chrome.runtime.sendMessage({action:'isImageBanned', url:audioSrc}, function (result) {
                                     if (!result) {
@@ -1086,7 +1085,7 @@ var hoverZoom = {
                                     }
                                 });                               
                             }
-
+                            */
                             loading = true;
                         }
                     } else {


### PR DESCRIPTION
- This fixes what #1515 was trying to fix
- setLoadImage used to set loadHoveredImage within callback so timeout can be set outside of callback. This makes clearTimeout use the correct timeout ID
- There is probably a smarter way of fixing this, but this works
