### PR TITLE
Add Addon ID to manifest for storage.sync support in firefox

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -14,6 +14,12 @@
     },
     "default_locale": "en",
     "minimum_chrome_version": "130",
+    "browser_specific_settings": {
+        "gecko": {
+            "id": "{92e6fe1c-6e1d-44e1-8bc6-d309e59406af}",
+            "strict_min_version": "130.0"
+        }
+    },
     "background": {
         "persistent": true,
         "scripts": [


### PR DESCRIPTION
This updates the manifest with```browser_specific_settings```which Firefox requires for storage.sync API, mainly the addon ID: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/storage/sync
- The ID used is the permanent ID assigned by AMO