### PR TITLE
Wordpress: Fix URLs with queries

### DIFF
--- a/plugins/wordpress_a.js
+++ b/plugins/wordpress_a.js
@@ -1,7 +1,7 @@
 ﻿var hoverZoomPlugins = hoverZoomPlugins || [];
 hoverZoomPlugins.push({
     name:'Wordpress',
-    version:'2.5',
+    version:'2.6',
     favicon:'worldpress.svg',
     prepareImgLinks:function (callback) {
 
@@ -15,13 +15,21 @@ hoverZoomPlugins.push({
         //      -> https://blind.com/wp-content/uploads/2016/09/motion_animation2.jpg
         // sample: https://www.pariszigzag.fr/wp-content/uploads/2023/05/hotel-de-matignon-@Benoit-Granier-Matignon-e1684853353287.jpeg
         //      -> https://www.pariszigzag.fr/wp-content/uploads/2023/05/hotel-de-matignon-@Benoit-Granier-Matignon.jpeg
+        // sample: https://i0.wp.com/lgbtqreads.com/wp-content/uploads/2024/12/ItsaLoveSkateRelationship-hc-c-678x1024-1.jpg?resize=199%2C300&ssl=1
+        //      -> https://i0.wp.com/lgbtqreads.com/wp-content/uploads/2024/12/ItsaLoveSkateRelationship-hc-c-678x1024-1.jpg
+        // sample: https://i0.wp.com/i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1653249383l/60405251.jpg?resize=184%2C278&ssl=1
+        //      -> https://i0.wp.com/i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1653249383l/60405251.jpg
         const re = /-\d+x\d+/ig;
         const re2 = /-e[0-9]{13}/;
         const re3 = /-(cropped|c-default|scaled)/;
 
-        $('img[src*="wp-content/"]').each(function () {
+        $('img[src*="wp-content/"], img[src*=".wp.com/i.gr-assets.com/"]').each(function () {
             const src = this.src;
-            const fullsizeUrl = src.replace(re, '').replace(re2, '').replace(re3, '');
+            const adjustFilename = src.replace(re, '').replace(re2, '').replace(re3, '');
+            const removeQueries = src.replace(/(jpg|jpeg|png|gif|webp)\?.*/, '$1');
+            const fullsizeUrl = removeQueries !== src ? removeQueries
+                                                      : adjustFilename;
+
             if (fullsizeUrl !== src) {
                 var link = $(this);
                 link.data().hoverZoomSrc = [fullsizeUrl, fullsizeUrl.replace(/jpg$/, 'jpeg')];


### PR DESCRIPTION
Turn this:

https://i0.wp.com/lgbtqreads.com/wp-content/uploads/2024/02/JFP_MMN_COV_mksm.jpg?resize=197%2C300&ssl=1

into this:

https://i0.wp.com/lgbtqreads.com/wp-content/uploads/2024/02/JFP_MMN_COV_mksm.jpg

Also avoid breaking URLs with a resolution baked into the file name if they also have queries at the end:

https://i0.wp.com/lgbtqreads.com/wp-content/uploads/2024/12/ItsaLoveSkateRelationship-hc-c-678x1024-1.jpg?resize=199%2C300&ssl=1

"-678x1024" is supposed to be there.

Also handle URLs that don't have "wp-content" in them even though they're hosted at i0.wp.com:

https://i0.wp.com/i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1665507126l/58762417._SX318_.jpg?resize=187%2C279&ssl=1

Technically some of these should also have the ``._crap_`` removed, but I had enough.

Test page:
https://lgbtqreads.com/2025/02/05/happy-national-girls-and-women-in-sports-day-2025/