### PR TITLE
Fix: TypeError message in Firefox

### DIFF
--- a/js/hoverzoom.js
+++ b/js/hoverzoom.js
@@ -3398,6 +3398,7 @@ var hoverZoom = {
 
         // extract content-Length & Last-Modified values from headers
         function parseHeaders(headers) {
+            headers = String(headers); //convert to string for .match
             let infos = {}
             let contentLength = headers.match(/content-length:(.*)/i);
             if (contentLength) {


### PR DESCRIPTION
Match requires variable to be a string in Firefox. This converts ```headers``` to a string so ```headers.match``` doesn't throw a TypeError message in Firefox