### PR TITLE
Change Media Length to Content Length in the options for clarity

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -612,7 +612,7 @@
         "description": "[options] Show Extension Detail"
     },
     "optShowDetailContentLength": {
-        "message": "Media Length",
+        "message": "Content Length",
         "description": "[options] Show Content Length Detail"
     },
     "optShowDetailDuration": {

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -592,7 +592,7 @@
         "description": "[options] Tooltip for details selector"
     },
     "optTitleBoxDetails": {
-        "message": "Detail(s) to show:",
+        "message": "Detail(s) shown:",
         "description": "[options] Title for details selector"
     },
     "optShowDetailHost": {

--- a/css/style.css
+++ b/css/style.css
@@ -73,7 +73,7 @@ label { margin: 3px; }
 
 .append-grid { 
     display: grid;
-    grid-template-columns:140px repeat(5,1fr);
+    grid-template-columns:150px repeat(3,1fr);
 }
 
 .title-box {

--- a/css/style.css
+++ b/css/style.css
@@ -73,7 +73,7 @@ label { margin: 3px; }
 
 .append-grid { 
     display: grid;
-    grid-template-columns:150px repeat(3,1fr);
+    grid-template-columns:132px repeat(5,1fr);
 }
 
 .title-box {


### PR DESCRIPTION
The header is called "Content Length" and all the variables for the detail in hoverzoom.js are "contentLength". This change makes the options text match.

Possibly unnecessary, I thought making the name match would be helpful.