### PR TITLE
Fix V3 Manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -21,7 +21,8 @@
         }
     },
     "background": {
-        "service_worker": "js/background.js"
+        "service_worker": "js/background.js",
+        "scripts": ["js/background.js"]
     },
     "options_ui": {
         "page": "html/options.html",


### PR DESCRIPTION
Firefox 136 still needs background.scripts in the manifest to work. This adds it