### PR TITLE
Fix BlobUrl not downloading in Firefox

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -51,8 +51,9 @@ async function ajaxRequest(request, sendResponse) {
                     case 'DOWNLOAD':
                         const arrayBuffer = await fetchResponse.arrayBuffer();
                         const contentType = fetchResponse.headers.get('content-type') || 'application/octet-stream';
-                        const blobBin = new Blob([arrayBuffer], { type: contentType });
-                        const blobUrl = await blobToDataURI(blobBin);
+                        const blobBin = new Blob([arrayBuffer], { type: contentType }); 
+                        const isChromiumBased = !!navigator.userAgentData?.brands?.some(item => item.brand === 'Chromium')
+                        const blobUrl = isChromiumBased ? await blobToDataURI(blobBin) : URL.createObjectURL(blobBin);
                         downloadFile(blobUrl, filename, conflictAction, sendResponse);
                         break;
                     case 'URL':

--- a/js/background.js
+++ b/js/background.js
@@ -75,9 +75,7 @@ async function ajaxRequest(request, sendResponse) {
 // For ajax-based image loading, Firefox needs an Object URL, Chrome needs a Data URI
 function createBlobUrl(blobBin) {
     const isChromiumBased = !!navigator.userAgentData?.brands?.some(item => item.brand === 'Chromium');
-    const blobDataURI = blobToDataURI(blobBin);
-    const blobObjectURL = URL.createObjectURL(blobBin);
-    return isChromiumBased ? blobDataURI : blobObjectURL;
+    return isChromiumBased ? blobToDataURI(blobBin) : URL.createObjectURL(blobBin);
 }
 
 function blobToDataURI(blob) {

--- a/js/background.js
+++ b/js/background.js
@@ -73,9 +73,9 @@ async function ajaxRequest(request, sendResponse) {
 }
 
 // For ajax-based image loading, Firefox needs an Object URL, Chrome needs a Data URI
-function createBlobUrl(blobBin) {
+async function createBlobUrl(blobBin) {
     const isChromiumBased = !!navigator.userAgentData?.brands?.some(item => item.brand === 'Chromium');
-    return isChromiumBased ? blobToDataURI(blobBin) : URL.createObjectURL(blobBin);
+    return isChromiumBased ? await blobToDataURI(blobBin) : URL.createObjectURL(blobBin);
 }
 
 function blobToDataURI(blob) {

--- a/js/background.js
+++ b/js/background.js
@@ -52,8 +52,7 @@ async function ajaxRequest(request, sendResponse) {
                         const arrayBuffer = await fetchResponse.arrayBuffer();
                         const contentType = fetchResponse.headers.get('content-type') || 'application/octet-stream';
                         const blobBin = new Blob([arrayBuffer], { type: contentType }); 
-                        const isChromiumBased = !!navigator.userAgentData?.brands?.some(item => item.brand === 'Chromium')
-                        const blobUrl = isChromiumBased ? await blobToDataURI(blobBin) : URL.createObjectURL(blobBin);
+                        const blobUrl = await createBlobUrl(blobBin);
                         downloadFile(blobUrl, filename, conflictAction, sendResponse);
                         break;
                     case 'URL':
@@ -71,6 +70,14 @@ async function ajaxRequest(request, sendResponse) {
         cLog(error);
         sendResponse(null);
     }
+}
+
+// For ajax-based image loading, Firefox needs an Object URL, Chrome needs a Data URI
+function createBlobUrl(blobBin) {
+    const isChromiumBased = !!navigator.userAgentData?.brands?.some(item => item.brand === 'Chromium');
+    const blobDataURI = blobToDataURI(blobBin);
+    const blobObjectURL = URL.createObjectURL(blobBin);
+    return isChromiumBased ? blobDataURI : blobObjectURL;
 }
 
 function blobToDataURI(blob) {

--- a/js/background.js
+++ b/js/background.js
@@ -51,7 +51,7 @@ async function ajaxRequest(request, sendResponse) {
                     case 'DOWNLOAD':
                         const arrayBuffer = await fetchResponse.arrayBuffer();
                         const contentType = fetchResponse.headers.get('content-type') || 'application/octet-stream';
-                        const blobBin = new Blob([arrayBuffer], { type: contentType }); 
+                        const blobBin = new Blob([arrayBuffer], { type: contentType });
                         const blobUrl = await createBlobUrl(blobBin);
                         downloadFile(blobUrl, filename, conflictAction, sendResponse);
                         break;


### PR DESCRIPTION
As described here: https://github.com/extesy/hoverzoom/issues/1585#issuecomment-2755606050:
Fixes dataURIs not downloading in Firefox by making the blobUrl an ObjectURL instead:

https://github.com/extesy/hoverzoom/blob/59dce25a66e89dfa26579bc44c4a7dce1e7cbaaa/js/background.js#L55
to
```js
        const isChromiumBased = !!navigator.userAgentData?.brands?.some(item => item.brand === 'Chromium')
        const blobUrl = isChromiumBased ? await blobToDataURI(blobBin) : URL.createObjectURL(blobBin);
```