### PR TITLE
Make downloads permission optional

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -575,6 +575,10 @@
         "message": "Add viewed pictures to the browser's history",
         "description": "[options] Add viewed pictures to the browser's history option"
     },
+    "optAllowMediaSaving": {
+        "message": "Allow saving media with action key",
+        "description": "[options] Allow saving media with action key option"
+    },
     "optFilterNSFW": {
         "message": "Exclude NSFW images (Reddit only)",
         "description": "[options] Exclude NSFW images (Reddit only) option"

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -576,8 +576,8 @@
         "description": "[options] Add viewed pictures to the browser's history option"
     },
     "optAllowMediaSaving": {
-        "message": "Allow saving media with action key",
-        "description": "[options] Allow saving media with action key option"
+        "message": "Enable saving media with action key",
+        "description": "[options] Enable saving media with action key option"
     },
     "optFilterNSFW": {
         "message": "Exclude NSFW images (Reddit only)",
@@ -1072,7 +1072,7 @@
         "description": "[options] Action key title"
     },
     "optSaveImageKeyDescription": {
-        "message": "Press this key to save the image or video you are currently viewing.",
+        "message": "Press this key to save the image or video you are currently viewing. (Requires 'Enable saving media with action key' to be checked)",
         "description": "[options] Action key description"
     },
     "optFullZoomKeyTitle": {

--- a/html/options.html
+++ b/html/options.html
@@ -468,6 +468,12 @@
                                     </label>
                                 </li>
                                 <li class="field">
+                                    <label class="checkbox" for="chkAllowMediaSaving">
+                                        <input type="checkbox" id="chkAllowMediaSaving"><span></span>
+                                        <div style="display:inline" data-i18n="optAllowMediaSaving"></div>
+                                    </label>
+                                </li>
+                                <li class="field">
                                     <label class="checkbox" for="chkFilterNSFW">
                                         <input type="checkbox" id="chkFilterNSFW"><span></span>
                                         <div style="display:inline" data-i18n="optFilterNSFW"></div>

--- a/js/background.js
+++ b/js/background.js
@@ -124,7 +124,7 @@ async function onMessage(message, sender, sendResponse) {
     options = await loadOptions();
     switch (message.action) {
         case 'downloadFileBlob':
-            cLog('check for download permission');
+            cLog('check for downloads permission');
             if (options.allowMediaSaving) {
                 cLog('downloadFileBlob: ' + message);
                 await ajaxRequest({
@@ -138,7 +138,7 @@ async function onMessage(message, sender, sendResponse) {
             }
             break;
         case 'downloadFile':
-            cLog('check for download permission');
+            cLog('check for downloads permission');
             if (options.allowMediaSaving) {
                 cLog('downloadFile: ' + message);
                 await downloadFile(message.url, message.filename, message.conflictAction, sendResponse);

--- a/js/background.js
+++ b/js/background.js
@@ -51,8 +51,9 @@ async function ajaxRequest(request, sendResponse) {
                     case 'DOWNLOAD':
                         const arrayBuffer = await fetchResponse.arrayBuffer();
                         const contentType = fetchResponse.headers.get('content-type') || 'application/octet-stream';
-                        const blobBin = new Blob([arrayBuffer], { type: contentType });
-                        const blobUrl = await blobToDataURI(blobBin);
+                        const blobBin = new Blob([arrayBuffer], { type: contentType }); 
+                        const isChromiumBased = !!navigator.userAgentData?.brands?.some(item => item.brand === 'Chromium')
+                        const blobUrl = isChromiumBased ? await blobToDataURI(blobBin) : URL.createObjectURL(blobBin);
                         downloadFile(blobUrl, filename, conflictAction, sendResponse);
                         break;
                     case 'URL':

--- a/js/background.js
+++ b/js/background.js
@@ -51,8 +51,10 @@ async function ajaxRequest(request, sendResponse) {
                     case 'DOWNLOAD':
                         const arrayBuffer = await fetchResponse.arrayBuffer();
                         const contentType = fetchResponse.headers.get('content-type') || 'application/octet-stream';
-                        const blobBin = new Blob([arrayBuffer], { type: contentType });
-                        const blobUrl = await createBlobUrl(blobBin);
+                        const blobBin = new Blob([arrayBuffer], { type: contentType }); 
+                        
+                        // For ajax-based image loading, Firefox needs an Object URL, Chrome needs a Data URI
+                        const blobUrl = isChromiumBased ? await blobToDataURI(blobBin) : URL.createObjectURL(blobBin);
                         downloadFile(blobUrl, filename, conflictAction, sendResponse);
                         break;
                     case 'URL':
@@ -72,10 +74,7 @@ async function ajaxRequest(request, sendResponse) {
     }
 }
 
-// For ajax-based image loading, Firefox needs an Object URL, Chrome needs a Data URI
 async function createBlobUrl(blobBin) {
-    const isChromiumBased = !!navigator.userAgentData?.brands?.some(item => item.brand === 'Chromium');
-    return isChromiumBased ? await blobToDataURI(blobBin) : URL.createObjectURL(blobBin);
 }
 
 function blobToDataURI(blob) {

--- a/js/background.js
+++ b/js/background.js
@@ -123,25 +123,19 @@ async function onMessage(message, sender, sendResponse) {
     options = await loadOptions();
     switch (message.action) {
         case 'downloadFileBlob':
-            cLog('check for downloads permission');
-            if (options.allowMediaSaving) {
-                cLog('downloadFileBlob: ' + message);
-                await ajaxRequest({
-                    method: 'GET',
-                    response: 'DOWNLOAD',
-                    url: message.url,
-                    filename: message.filename,
-                    conflictAction: message.conflictAction,
-                    headers: message.headers
-                }, sendResponse);
-            }
+            cLog('downloadFileBlob: ' + message);
+            await ajaxRequest({
+                method: 'GET',
+                response: 'DOWNLOAD',
+                url: message.url,
+                filename: message.filename,
+                conflictAction: message.conflictAction,
+                headers: message.headers
+            }, sendResponse);
             break;
         case 'downloadFile':
-            cLog('check for downloads permission');
-            if (options.allowMediaSaving) {
-                cLog('downloadFile: ' + message);
-                await downloadFile(message.url, message.filename, message.conflictAction, sendResponse);
-            }
+            cLog('downloadFile: ' + message);
+            await downloadFile(message.url, message.filename, message.conflictAction, sendResponse);
             break;
         case 'ajaxGet':
             await ajaxRequest({

--- a/js/background.js
+++ b/js/background.js
@@ -75,9 +75,7 @@ async function ajaxRequest(request, sendResponse) {
 // For ajax-based image loading, Firefox needs an Object URL, Chrome needs a Data URI
 function createBlobUrl(blobBin) {
     const isChromiumBased = !!navigator.userAgentData?.brands?.some(item => item.brand === 'Chromium');
-    const blobDataURI = blobToDataURI(blobBin);
-    const blobObjectURL = URL.createObjectURL(blobBin);
-    return isChromiumBased ? blobDataURI : blobObjectURL;
+    return isChromiumBased ? blobToDataURI(blobBin) : URL.createObjectURL(blobBin);
 }
 
 function blobToDataURI(blob) {

--- a/js/background.js
+++ b/js/background.js
@@ -73,9 +73,9 @@ async function ajaxRequest(request, sendResponse) {
 }
 
 // For ajax-based image loading, Firefox needs an Object URL, Chrome needs a Data URI
-function createBlobUrl(blobBin) {
+async function createBlobUrl(blobBin) {
     const isChromiumBased = !!navigator.userAgentData?.brands?.some(item => item.brand === 'Chromium');
-    return isChromiumBased ? blobToDataURI(blobBin) : URL.createObjectURL(blobBin);
+    return isChromiumBased ? await blobToDataURI(blobBin) : URL.createObjectURL(blobBin);
 }
 
 function blobToDataURI(blob) {

--- a/js/background.js
+++ b/js/background.js
@@ -74,9 +74,6 @@ async function ajaxRequest(request, sendResponse) {
     }
 }
 
-async function createBlobUrl(blobBin) {
-}
-
 function blobToDataURI(blob) {
     return new Promise((resolve, reject) => {
         const reader = new FileReader();

--- a/js/background.js
+++ b/js/background.js
@@ -51,9 +51,8 @@ async function ajaxRequest(request, sendResponse) {
                     case 'DOWNLOAD':
                         const arrayBuffer = await fetchResponse.arrayBuffer();
                         const contentType = fetchResponse.headers.get('content-type') || 'application/octet-stream';
-                        const blobBin = new Blob([arrayBuffer], { type: contentType }); 
-                        const isChromiumBased = !!navigator.userAgentData?.brands?.some(item => item.brand === 'Chromium')
-                        const blobUrl = isChromiumBased ? await blobToDataURI(blobBin) : URL.createObjectURL(blobBin);
+                        const blobBin = new Blob([arrayBuffer], { type: contentType });
+                        const blobUrl = await createBlobUrl(blobBin);
                         downloadFile(blobUrl, filename, conflictAction, sendResponse);
                         break;
                     case 'URL':
@@ -71,6 +70,12 @@ async function ajaxRequest(request, sendResponse) {
         cLog(error);
         sendResponse(null);
     }
+}
+
+// For ajax-based image loading, Firefox needs an Object URL, Chrome needs a Data URI
+async function createBlobUrl(blobBin) {
+    const isChromiumBased = !!navigator.userAgentData?.brands?.some(item => item.brand === 'Chromium');
+    return isChromiumBased ? await blobToDataURI(blobBin) : URL.createObjectURL(blobBin);
 }
 
 function blobToDataURI(blob) {

--- a/js/background.js
+++ b/js/background.js
@@ -124,19 +124,25 @@ async function onMessage(message, sender, sendResponse) {
     options = await loadOptions();
     switch (message.action) {
         case 'downloadFileBlob':
-            cLog('downloadFileBlob: ' + message);
-            await ajaxRequest({
-                method: 'GET',
-                response: 'DOWNLOAD',
-                url: message.url,
-                filename: message.filename,
-                conflictAction: message.conflictAction,
-                headers: message.headers
-            }, sendResponse);
+            cLog('check for download permission');
+            if (options.allowMediaSaving) {
+                cLog('downloadFileBlob: ' + message);
+                await ajaxRequest({
+                    method: 'GET',
+                    response: 'DOWNLOAD',
+                    url: message.url,
+                    filename: message.filename,
+                    conflictAction: message.conflictAction,
+                    headers: message.headers
+                }, sendResponse);
+            }
             break;
         case 'downloadFile':
-            cLog('downloadFile: ' + message);
-            await downloadFile(message.url, message.filename, message.conflictAction, sendResponse);
+            cLog('check for download permission');
+            if (options.allowMediaSaving) {
+                cLog('downloadFile: ' + message);
+                await downloadFile(message.url, message.filename, message.conflictAction, sendResponse);
+            }
             break;
         case 'ajaxGet':
             await ajaxRequest({

--- a/js/background.js
+++ b/js/background.js
@@ -51,7 +51,7 @@ async function ajaxRequest(request, sendResponse) {
                     case 'DOWNLOAD':
                         const arrayBuffer = await fetchResponse.arrayBuffer();
                         const contentType = fetchResponse.headers.get('content-type') || 'application/octet-stream';
-                        const blobBin = new Blob([arrayBuffer], { type: contentType });
+                        const blobBin = new Blob([arrayBuffer], { type: contentType }); 
                         const blobUrl = await createBlobUrl(blobBin);
                         downloadFile(blobUrl, filename, conflictAction, sendResponse);
                         break;
@@ -73,9 +73,11 @@ async function ajaxRequest(request, sendResponse) {
 }
 
 // For ajax-based image loading, Firefox needs an Object URL, Chrome needs a Data URI
-async function createBlobUrl(blobBin) {
+function createBlobUrl(blobBin) {
     const isChromiumBased = !!navigator.userAgentData?.brands?.some(item => item.brand === 'Chromium');
-    return isChromiumBased ? await blobToDataURI(blobBin) : URL.createObjectURL(blobBin);
+    const blobDataURI = blobToDataURI(blobBin);
+    const blobObjectURL = URL.createObjectURL(blobBin);
+    return isChromiumBased ? blobDataURI : blobObjectURL;
 }
 
 function blobToDataURI(blob) {

--- a/js/background.js
+++ b/js/background.js
@@ -51,7 +51,7 @@ async function ajaxRequest(request, sendResponse) {
                     case 'DOWNLOAD':
                         const arrayBuffer = await fetchResponse.arrayBuffer();
                         const contentType = fetchResponse.headers.get('content-type') || 'application/octet-stream';
-                        const blobBin = new Blob([arrayBuffer], { type: contentType }); 
+                        const blobBin = new Blob([arrayBuffer], { type: contentType });
                         const blobUrl = await createBlobUrl(blobBin);
                         downloadFile(blobUrl, filename, conflictAction, sendResponse);
                         break;

--- a/js/common.js
+++ b/js/common.js
@@ -19,6 +19,7 @@ const factorySettings = {
     galleriesMouseWheel: true,
     disableMouseWheelForVideo: false,
     addToHistory: false,
+    allowMediaSaving: false,
     alwaysPreload: false,
     displayDelay: 100,
     displayDelayVideo: 500,

--- a/js/hoverzoom.js
+++ b/js/hoverzoom.js
@@ -3690,7 +3690,7 @@ var hoverZoom = {
                 savePlaylist();
                 saveSubtitles();
             } else {
-                alert('Saving media is not enabled. Please enable saving media with action key in the Hover Zoom+ options.')
+                alert('Saving media is not enabled. To save media, please enable saving media with action key in the Hover Zoom+ options.')
             }
         }
 

--- a/js/hoverzoom.js
+++ b/js/hoverzoom.js
@@ -3690,7 +3690,7 @@ var hoverZoom = {
                 savePlaylist();
                 saveSubtitles();
             } else {
-                alert('Saving media is not enabled. To save media, please enable saving media with action key in the Hover Zoom+ options.')
+                alert('Saving media is disabled. To save media, please enable "saving media with action key" on the HoverZoom\'s advanced options page.')
             }
         }
 

--- a/js/hoverzoom.js
+++ b/js/hoverzoom.js
@@ -3690,7 +3690,7 @@ var hoverZoom = {
                 savePlaylist();
                 saveSubtitles();
             } else {
-                alert('Saving media with an action key is not enabled. Please enable it in the Hover Zoom+ options.')
+                alert('Saving media is not enabled. Please enable saving media with action key in the Hover Zoom+ options.')
             }
         }
 

--- a/js/hoverzoom.js
+++ b/js/hoverzoom.js
@@ -3682,11 +3682,16 @@ var hoverZoom = {
         }
 
         function saveImage() {
-            saveImg();
-            saveVideo();
-            saveAudio();
-            savePlaylist();
-            saveSubtitles();
+            cLog('check for media saving option');
+            if (options.allowMediaSaving) {
+                saveImg();
+                saveVideo();
+                saveAudio();
+                savePlaylist();
+                saveSubtitles();
+            } else {
+                alert('Saving media with an action key is not enabled. Please enable it in the Hover Zoom+ options.')
+            }
         }
 
         function copyLink() {

--- a/js/options.js
+++ b/js/options.js
@@ -486,6 +486,15 @@ function initAddToHistory() {
 }
 
 function initAllowMediaSaving() {
+    // Check if permission was enabled/disabled outside of options page
+    chrome.permissions.contains({permissions: ['downloads']}, (contained) => {
+        if (contained){
+            $('#chkAllowMediaSaving').trigger('gumby.check');
+        } else {
+            $('#chkAllowMediaSaving').trigger('gumby.uncheck');
+        }
+        savePermissionOptions();
+    });
     $('#chkAllowMediaSaving').parent().on('gumby.onChange', chkAllowMediaSavingModeOnChange);
 }
 

--- a/js/options.js
+++ b/js/options.js
@@ -486,15 +486,6 @@ function initAddToHistory() {
 }
 
 function initAllowMediaSaving() {
-    // Check if permission was enabled/disabled outside of options page
-    chrome.permissions.contains({permissions: ['downloads']}, (contained) => {
-        if (contained){
-            $('#chkAllowMediaSaving').trigger('gumby.check');
-        } else {
-            $('#chkAllowMediaSaving').trigger('gumby.uncheck');
-        }
-        savePermissionOptions();
-    });
     $('#chkAllowMediaSaving').parent().on('gumby.onChange', chkAllowMediaSavingModeOnChange);
 }
 

--- a/manifest.json
+++ b/manifest.json
@@ -37,13 +37,13 @@
     },
     "permissions": [
         "declarativeNetRequest",
-        "downloads",
         "scripting",
         "storage",
         "tabs",
         "unlimitedStorage"
     ],
     "optional_permissions": [
+        "downloads",
         "history"
     ],
     "host_permissions": [


### PR DESCRIPTION
- Adds a new checkbox in the advanced tab of the options page which is used to request 'downloads' permission
- Both Firefox and Chrome get a prompt requesting the user to grant permission when the checkbox is ticked
- No longer requires 'downloads' permission to work
- Resolves #1584