### PR TITLE
Add permissions checking function to background

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -142,6 +142,11 @@ async function onMessage(message, sender, sendResponse) {
                 headers: message.headers
             }, sendResponse);
             break;
+        case 'getPermissionsContains':
+            chrome.permissions.contains({permissions: message.permissions}, function(granted) {
+                sendResponse(granted);
+            });
+            break;
         case 'ajaxGetHeaders':
             await ajaxRequest({
                 method: 'HEAD',

--- a/js/hoverzoom.js
+++ b/js/hoverzoom.js
@@ -3682,7 +3682,12 @@ var hoverZoom = {
         }
 
         function saveImage() {
-            cLog('check for media saving option');
+            cLog('check for permission');
+            chrome.runtime.sendMessage({action:'getPermissionsContains', permissions: ['downloads']}, 
+                function(response) {
+                    options.allowMediaSaving = response;
+            });
+                
             if (options.allowMediaSaving) {
                 saveImg();
                 saveVideo();

--- a/js/hoverzoom.js
+++ b/js/hoverzoom.js
@@ -3685,18 +3685,16 @@ var hoverZoom = {
             cLog('check for permission');
             chrome.runtime.sendMessage({action:'getPermissionsContains', permissions: ['downloads']}, 
                 function(response) {
-                    options.allowMediaSaving = response;
-            });
-                
-            if (options.allowMediaSaving) {
-                saveImg();
-                saveVideo();
-                saveAudio();
-                savePlaylist();
-                saveSubtitles();
-            } else {
-                alert('Saving media is disabled. To save media, please enable "saving media with action key" on the HoverZoom\'s advanced options page.')
-            }
+                    if (response === true) {
+                        saveImg();
+                        saveVideo();
+                        saveAudio();
+                        savePlaylist();
+                        saveSubtitles();
+                    } else {
+                        alert('Saving media is disabled. To save media, please enable "saving media with action key" on the HoverZoom\'s advanced options page.')
+                    }            
+                });
         }
 
         function copyLink() {

--- a/js/options.js
+++ b/js/options.js
@@ -176,6 +176,14 @@ async function restoreOptionsFromFactorySettings() {
 // Restores options from storage
 async function restoreOptions(optionsFromFactorySettings) {
     options = optionsFromFactorySettings || await loadOptions();
+    // Check if permission was enabled/disabled outside of options page
+    chrome.permissions.contains({permissions: ['downloads']}, (contained) => {
+     if (contained){
+        options.allowMediaSaving = true;
+     } else {
+        options.allowMediaSaving = false;
+    }
+ });
 
     $('#chkExtensionEnabled').trigger(options.extensionEnabled ? 'gumby.check' : 'gumby.uncheck');
     $('#chkDarkMode').trigger(options.darkMode ? 'gumby.check' : 'gumby.uncheck');
@@ -306,6 +314,7 @@ async function restoreOptions(optionsFromFactorySettings) {
     $('#chkShowDetailDimensions').trigger(options.showDetailDimensions ? 'gumby.check' : 'gumby.uncheck');
 
     $('#chkAddToHistory').trigger(options.addToHistory ? 'gumby.check' : 'gumby.uncheck');
+    $('#chkAllowMediaSaving').trigger(options.allowMediaSaving ? 'gumby.check' : 'gumby.uncheck');
 
     $('#chkFilterNSFW').trigger(options.filterNSFW ? 'gumby.check' : 'gumby.uncheck');
     $('#chkAlwaysPreload').trigger(options.alwaysPreload ? 'gumby.check' : 'gumby.uncheck');
@@ -485,15 +494,6 @@ function initAddToHistory() {
 }
 
 function initAllowMediaSaving() {
-    // Check if permission was enabled/disabled outside of options page
-    chrome.permissions.contains({permissions: ['downloads']}, (contained) => {
-        if (contained){
-            $('#chkAllowMediaSaving').trigger('gumby.check');
-        } else {
-            $('#chkAllowMediaSaving').trigger('gumby.uncheck');
-        }
-        savePermissionOptions();
-    });
     $('#chkAllowMediaSaving').parent().on('gumby.onChange', chkAllowMediaSavingModeOnChange);
 }
 

--- a/js/options.js
+++ b/js/options.js
@@ -306,7 +306,6 @@ async function restoreOptions(optionsFromFactorySettings) {
     $('#chkShowDetailDimensions').trigger(options.showDetailDimensions ? 'gumby.check' : 'gumby.uncheck');
 
     $('#chkAddToHistory').trigger(options.addToHistory ? 'gumby.check' : 'gumby.uncheck');
-    $('#chkAllowMediaSaving').trigger(options.allowMediaSaving ? 'gumby.check' : 'gumby.uncheck');
 
     $('#chkFilterNSFW').trigger(options.filterNSFW ? 'gumby.check' : 'gumby.uncheck');
     $('#chkAlwaysPreload').trigger(options.alwaysPreload ? 'gumby.check' : 'gumby.uncheck');

--- a/js/options.js
+++ b/js/options.js
@@ -176,14 +176,6 @@ async function restoreOptionsFromFactorySettings() {
 // Restores options from storage
 async function restoreOptions(optionsFromFactorySettings) {
     options = optionsFromFactorySettings || await loadOptions();
-    // Check if permission was enabled/disabled outside of options page
-    chrome.permissions.contains({permissions: ['downloads']}, (contained) => {
-     if (contained){
-        options.allowMediaSaving = true;
-     } else {
-        options.allowMediaSaving = false;
-    }
- });
 
     $('#chkExtensionEnabled').trigger(options.extensionEnabled ? 'gumby.check' : 'gumby.uncheck');
     $('#chkDarkMode').trigger(options.darkMode ? 'gumby.check' : 'gumby.uncheck');
@@ -494,6 +486,11 @@ function initAddToHistory() {
 }
 
 function initAllowMediaSaving() {
+    // Check if permission was enabled/disabled outside of options page
+    chrome.permissions.contains({permissions: ['downloads']}, (contained) => {
+        $('#chkAllowMediaSaving').trigger(contained ? 'gumby.check' : 'gumby.uncheck');
+        savePermissionOptions();
+    });
     $('#chkAllowMediaSaving').parent().on('gumby.onChange', chkAllowMediaSavingModeOnChange);
 }
 


### PR DESCRIPTION
This allows hoverzoom.js to check for 'downloads' permission before saving an image, in case the permission was already active or changed outside the options page.  This also allows an alert to be sent from the main script. The permission could instead be checked in hoverzoom.js ```init()``` so it's not called every time a user tries to save an image