### PR TITLE
Fix copy image and copy image url

### DIFF
--- a/js/hoverzoom.js
+++ b/js/hoverzoom.js
@@ -3718,6 +3718,7 @@ var hoverZoom = {
                         func(blob);
                     },'image/png')
                 }
+                // Cross origin required to be set in order to convert canvas to blob
                 img.setAttribute('crossorigin', 'anonymous')
                 img.src = path;
             }

--- a/js/hoverzoom.js
+++ b/js/hoverzoom.js
@@ -1212,12 +1212,7 @@ var hoverZoom = {
                     return;
                 }
                 case options.copyImageKey:
-                    if (isChromiumBased) {
-                        if (keyCode === options.copyImageKey) {
-                            copyImage();
-                            return false;
-                        }
-                    }
+                    copyImage();
                     return false;
                 case options.copyImageUrlKey:
                     copyLink();
@@ -2933,11 +2928,9 @@ var hoverZoom = {
                     return false;
                 }
                 // "Copy image" key
-                if (isChromiumBased) {
-                    if (keyCode === options.copyImageKey) {
-                        copyImage();
-                        return false;
-                    }
+                if (keyCode === options.copyImageKey) {
+                    copyImage();
+                    return false;
                 }
                 // "Copy image url" key
                 if (keyCode === options.copyImageUrlKey) {
@@ -3711,18 +3704,32 @@ var hoverZoom = {
         function copyImage() {
             if (! srcDetails.url) return;
             const url = srcDetails.url.replaceAll(' ', '%20');
-
-            fetch(url)
-                .then(resp => resp.blob())
-                .then(blob => blob.arrayBuffer())
-                .then(buffer => {
-                    // Lie about the data type
-                    // Note: This does not work on FireFox
-                    const blob = new Blob([buffer], {'type': 'image/png'});
-                    const item = new ClipboardItem({'image/png': blob});
-                    navigator.clipboard.write([item]);
-                });
-
+            const img = new Image;
+            const c = document.createElement('canvas');
+            const ctx = c.getContext('2d');
+            
+            // Converts an image into a blob in order to write to the clipboard
+            function setCanvasImage(path,func){
+                img.onload = function(){
+                    c.width = this.naturalWidth;
+                    c.height = this.naturalHeight;
+                    ctx.drawImage(this,0,0)
+                    c.toBlob(blob=>{
+                        func(blob);
+                    },'image/png')
+                }
+                img.setAttribute('crossorigin', 'anonymous')
+                img.src = path;
+            }
+            
+            setCanvasImage(url,(imgBlob)=>{
+                cLog('Copying image to clipboard');
+                navigator.clipboard.write([
+                    new ClipboardItem({'image/png': imgBlob})
+                ])
+                .then(e=>{cLog('Image copied to clipboard')})
+                .catch(e=>{cLog(e)})
+            })
         }
 
         function saveImg() {

--- a/js/options.js
+++ b/js/options.js
@@ -10,7 +10,7 @@ function getMilliseconds(ctrl) {
 }
 
 // Options that are only enabled for Chromium-based browsers
-const chromiumOnly = ['copyImageKey', 'copyImageUrlKey'];
+const chromiumOnly = [];
 
 function initActionKeys() {
     actionKeys

--- a/manifest.json
+++ b/manifest.json
@@ -2183,7 +2183,7 @@
         },
         {
             "js": ["plugins/civitai.js"],
-            "matches": ["*://*.civitai.com/*"]
+            "matches": ["*://*.civitai.com/*", "*://*.civitai.green/*"]
         }
     ]
 }

--- a/ruleset.json
+++ b/ruleset.json
@@ -365,5 +365,33 @@
             "urlFilter": "||cdn13.com/",
             "resourceTypes": ["image", "media"]
         }
+    },
+    {
+        "id": 150,
+        "priority": 1,
+        "action": {
+            "type": "modifyHeaders",
+            "responseHeaders": [
+                {"header": "Access-Control-Allow-Origin", "operation": "set", "value": "*"}
+            ]
+        },
+        "condition": {
+            "urlFilter": "||bsky.app/",
+            "resourceTypes": ["image", "media"]
+        }
+    },
+    {
+        "id": 160,
+        "priority": 1,
+        "action": {
+            "type": "modifyHeaders",
+            "responseHeaders": [
+                {"header": "Access-Control-Allow-Origin", "operation": "set", "value": "*"}
+            ]
+        },
+        "condition": {
+            "urlFilter": "||furaffinity.net/",
+            "resourceTypes": ["image", "media"]
+        }
     }
 ]


### PR DESCRIPTION
This attempts to fix "Copy Image" and "Copy Image URL" so it works in Chrome and Firefox. The main issue is Chrome requires "Access-Control-Allow-Origin" headers to be set. This is infeasible as it would have to be set for every site, unless it is set when the "Copy Image" key is pressed
- will fix #1607 once cors issue is resolved