### PR TITLE
Added an option to disable looping albums

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -243,6 +243,14 @@
         "message": "Navigate album with the mouse wheel",
         "description": "[options] Tooltip for use mousewheel to navigate albums option"
     },
+    "optGalleriesLoopEnabled": {
+        "message": "Loop albums",
+        "description": "[options] Loop albums option"
+    },
+    "optGalleriesLoopEnabledTooltip": {
+        "message": "When navigating past the end of an album, loop back to the start",
+        "description": "[options] Tooltip for loop albums option"
+    },
     "optDisableMouseWheelForVideo": {
         "message": "Don't use mousewheel to navigate within video (action keys will still work)",
         "description": "[options] Allows you to scroll through albums with the mousewheel but does not change behavior of GFY/Videos"

--- a/html/options.html
+++ b/html/options.html
@@ -143,6 +143,14 @@
                                         </label>
                                     </li>
                                 </div>
+                                <div class="ttip" data-i18n-tooltip="optGalleriesLoopEnabledTooltip">
+                                    <li class="field">
+                                        <label class="checkbox" for="chkGalleriesLoopEnabled">
+                                            <input type="checkbox" id="chkGalleriesLoopEnabled"><span></span>
+                                            <div style="display:inline" data-i18n="optGalleriesLoopEnabled"></div>
+                                        </label>
+                                    </li>
+                                </div>
                                 <div class="ttip" data-i18n-tooltip="optEnableViewerShadowTooltip">
                                     <li class="field">
                                         <label class="checkbox" for="chkViewerShadowEnabled" style="margin-bottom:0px;">

--- a/js/common.js
+++ b/js/common.js
@@ -17,6 +17,7 @@ const factorySettings = {
     pageActionEnabled: true,
     showHighRes: true,
     galleriesMouseWheel: true,
+    galleriesLoopEnabled: true,
     disableMouseWheelForVideo: false,
     alwaysPreload: false,
     displayDelay: 100,

--- a/js/hoverzoom.js
+++ b/js/hoverzoom.js
@@ -3990,8 +3990,13 @@ var hoverZoom = {
                 return; // no gallery to rotate or gallery with only one image
             }
 
-            var l = data.hoverZoomGallerySrc.length;
-            data.hoverZoomGalleryIndex = (data.hoverZoomGalleryIndex + rot + l) % l;
+            var len = data.hoverZoomGallerySrc.length;
+            if ((data.hoverZoomGalleryIndex + rot < 0 || data.hoverZoomGalleryIndex + rot >= len) && !options.galleriesLoopEnabled) {
+                // The user attempted to naviagte past the start/end of an album, but looping is disabled, so we do
+                // nothing.
+                return;
+            }
+            data.hoverZoomGalleryIndex = (data.hoverZoomGalleryIndex + rot + len) % len;
             updateImageFromGallery(link);
 
             data.hoverZoomSrcIndex = 0;
@@ -3999,7 +4004,7 @@ var hoverZoom = {
             hzGallery.text('.../' + data.hoverZoomGallerySrc.length);
 
             loadNextGalleryImage();
-            preloadGalleryImage((data.hoverZoomGalleryIndex + rot + l) % l);
+            preloadGalleryImage((data.hoverZoomGalleryIndex + rot + len) % len);
         }
 
         function loadNextGalleryImage() {

--- a/js/options.js
+++ b/js/options.js
@@ -46,6 +46,7 @@ async function saveOptions(exportSettings = false) {
     options.showWhileLoading = $('#chkShowWhileLoading')[0].checked;
     options.showHighRes = $('#chkShowHighRes')[0].checked;
     options.galleriesMouseWheel = $('#chkGalleriesMouseWheel')[0].checked;
+    options.galleriesLoopEnabled = $('#chkGalleriesLoopEnabled')[0].checked;
     options.disableMouseWheelForVideo = $('#chkDisableMouseWheelForVideo')[0].checked;
     options.displayDelay = getMilliseconds($('#txtDisplayDelay'));
     options.displayDelayVideo = getMilliseconds($('#txtDisplayDelayVideo'));
@@ -195,6 +196,7 @@ async function restoreOptions(optionsFromFactorySettings) {
     $('#chkShowWhileLoading').trigger(options.showWhileLoading ? 'gumby.check' : 'gumby.uncheck');
     $('#chkShowHighRes').trigger(options.showHighRes ? 'gumby.check' : 'gumby.uncheck');
     $('#chkGalleriesMouseWheel').trigger(options.galleriesMouseWheel ? 'gumby.check' : 'gumby.uncheck');
+    $('#chkGalleriesLoopEnabled').trigger(options.galleriesLoopEnabled ? 'gumby.check' : 'gumby.uncheck');
     $('#chkDisableMouseWheelForVideo').trigger(options.disableMouseWheelForVideo ? 'gumby.check' : 'gumby.uncheck');
     $('#txtDisplayDelay').val((options.displayDelay || 0) / 1000);
     $('#txtDisplayDelayVideo').val((options.displayDelayVideo || 0) / 1000);


### PR DESCRIPTION
The new option, `galleriesLoopEnabled`, is true by default. If disabled, navigating past the beginning or end of an album will do nothing, rather than looping back to the other side of it.

I created this PR after I realized that I could just do https://github.com/extesy/hoverzoom/issues/1618 myself. :)

Unfortunately, I have no idea how to create all the translations for the option description, so that'll have to be done before this PR can be accepted. Is there some script I can run that will auto-translate the `en` locale message that I did write?