### PR TITLE
Fix dimensions details

### DIFF
--- a/js/hoverzoom.js
+++ b/js/hoverzoom.js
@@ -2298,7 +2298,7 @@ var hoverZoom = {
         function getSrcDetails(link) {
             let details = {};
             if (!srcDetails.audio || srcDetails.video) {
-                if (srcDetails.naturalWidth) details.dimensions = Math.round(srcDetails.naturalWidth / parseInt(options.zoomFactor)) + 'x' + Math.round(srcDetails.naturalHeight / parseInt(options.zoomFactor));
+                if (srcDetails.naturalWidth) details.dimensions = srcDetails.naturalWidth + 'x' + srcDetails.naturalHeight;
                 if (srcDetails.naturalWidth) details.ratio = getImgRatio(srcDetails.naturalWidth, srcDetails.naturalHeight);
                 let displayedWidth = imgFullSize.width() || imgFullSize[0].width;
                 if (srcDetails.naturalWidth) details.scale = Math.round(100.0 * displayedWidth / srcDetails.naturalWidth) + '%';


### PR DESCRIPTION
The dimensions details should now display the image's natural size.

Apparently since its introduction by commit e891d02b7ab9080e522c5028a978df9d6987bb16, the dimensions details have divided the image's natural size by the the zoom factor. I'm not sure why this was done. *Multiplying* by the zoom factor would at least compute the displayed size (although I think this is a less desirable metric to show than the natural size). But dividing doesn't seem to produce any sensible metric.