### PR TITLE
Always open new tabs next to the current tab

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -200,10 +200,8 @@ async function onMessage(message, sender, sendResponse) {
             });
             break;
         case 'openViewTab':
-            chrome.tabs.query({active: true}, function (tabs) {
-                message.createData.index = tabs[0].index;
-                if (!message.createData.active)
-                    message.createData.index++;
+            chrome.tabs.query({active: true, currentWindow: true}, function (tabs) {
+                message.createData.index = tabs[0].index + 1;
                 let url = message.createData.url;
                 if (url.indexOf('facebook.com/photo/download') !== -1) {
                     message.createData.url = 'data:text/html,<img src="' + url + '">';


### PR DESCRIPTION
The [`chrome.tabs.query({active: true})`](https://developer.chrome.com/docs/extensions/reference/api/tabs#method-query) returns a list of active tabs across *all* browser windows. This means that picking `tabs[0]` doesn't necessarily correspond to the current window which can cause new tabs to be positioned in odd locations.

Additionally, the original implementation chose to open a new tab after the current tab only in case of background tabs (using `shift`). Non-`shift` uses opened the new tab at the current index, which had the effect of seemingly opening the new tab *before* the current tab. This has been simplified to always open a new tab *after* the current tab.

Fixes #1649 

Might also possibly be a fix for the odd behaviour explained in #336 