### PR TITLE
Fix for erratic scrolling

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -499,6 +499,18 @@
         "message": "milliseconds",
         "description": "[options] Unit name (pixel) for hold time amount"
     },
+    "optScrollWheelCooldown": {
+        "message": "Scrollwheel cooldown:",
+        "description": "[options] Mouse scroll wheel cooldown"
+    },
+    "optScrollWheelCooldownTooltip": {
+        "message": "Amount of time required between mouse scroll events before another action is triggered",
+        "description": "[options] Tooltip for mouse scrollwheel delay"
+    },
+    "optScrollWheelCooldownUnit": {
+        "message": "milliseconds",
+        "description": "[options] Unit name (pixel) for hold time amount"
+    },
     "optSectionZoomSpeed": {
         "message": "Zoom speed",
         "description": "[options] Page section for zoom speed"

--- a/html/options.html
+++ b/html/options.html
@@ -394,6 +394,16 @@
                                         </label>
                                     </li>
                                 </div>
+
+                                <div class="ttip" data-i18n-tooltip="optScrollWheelCooldownTooltip">
+                                    <li class="append field">
+                                        <label class="inline" for="txtScrollWheelCooldown">
+                                            <div style="display:inline" data-i18n="optScrollWheelCooldown"></div>
+                                            <input class="xnarrow input" type="range" name="points" min="0" max="1000" step="50" id="rngScrollWheelCooldown">
+                                            <input class="xnarrow text input" type="text" id="txtScrollWheelCooldown"><span class="adjoined xnarrow" data-i18n="optScrollWheelCooldownUnit"></span>
+                                        </label>
+                                    </li>
+                                </div>
                             </ul>
                         </fieldset>
                         <fieldset>

--- a/js/common.js
+++ b/js/common.js
@@ -12,6 +12,7 @@ const factorySettings = {
     playAudio: false,
     audioVolume: 0.25,
     mouseClickHoldTime: 250,
+    scrollWheelCooldown: 0,
     lockImageZoomFactorEnabled: true,
     lockImageZoomDefaultEnabled: false,
     pageActionEnabled: true,

--- a/js/hoverzoom.js
+++ b/js/hoverzoom.js
@@ -2786,7 +2786,7 @@ var hoverZoom = {
                 posViewer();
                 panLockedViewer(event);
             } else {
-                if (now - lastScrollTime < 350) { 
+                if (now - lastScrollTime < options.scrollWheelCooldown) { 
                     event.preventDefault();
                     return;
                 }

--- a/js/options.js
+++ b/js/options.js
@@ -39,6 +39,7 @@ async function saveOptions(exportSettings = false) {
     options.playAudio = $('#chkPlayAudio')[0].checked;
     options.audioVolume = $('#txtAudioVolume')[0].value / 100;
     options.mouseClickHoldTime = $('#txtMouseClickHoldTime')[0].value;
+    options.scrollWheelCooldown = $('#txtScrollWheelCooldown')[0].value;
     options.mouseUnderlap = $('#chkMouseUnderlap')[0].checked;
     options.lockImageZoomFactorEnabled = $('#chkLockImageZoomFactorEnabled')[0].checked;
     options.lockImageZoomDefaultEnabled = $('#chkLockImageZoomDefaultEnabled')[0].checked;
@@ -189,6 +190,8 @@ async function restoreOptions(optionsFromFactorySettings) {
     $('#txtAudioVolume').val(parseInt(options.audioVolume * 100));
     $('#rngMouseClickHoldTime').val(parseInt(options.mouseClickHoldTime));
     $('#txtMouseClickHoldTime').val(parseInt(options.mouseClickHoldTime));
+    $('#rngScrollWheelCooldown').val(parseInt(options.scrollWheelCooldown));
+    $('#txtScrollWheelCooldown').val(parseInt(options.scrollWheelCooldown));
     $('#chkMouseUnderlap').trigger(options.mouseUnderlap ? 'gumby.check' : 'gumby.uncheck');
     $('#chkLockImageZoomFactorEnabled').trigger(options.lockImageZoomFactorEnabled ? 'gumby.check' : 'gumby.uncheck');
     $('#chkLockImageZoomDefaultEnabled').trigger(options.lockImageZoomDefaultEnabled ? 'gumby.check' : 'gumby.uncheck');
@@ -636,6 +639,15 @@ function updateRngMouseClickHoldTime() {
     $('#rngMouseClickHoldTime').val(this.value);
 }
 
+function updateTxtScrollWheelCooldown() {
+    $('#txtScrollWheelCooldown')[0].value = this.value;
+}
+
+function updateRngScrollWheelCooldown() {
+    this.value = integerOnChange(this.value);
+    $('#rngScrollWheelCooldown').val(this.value);
+}
+
 function updateDarkMode() {
     if ($('#chkDarkMode')[0].checked) {
         $('body').addClass('darkmode');
@@ -762,6 +774,8 @@ $(async function () {
     $('#txtAudioVolume').change(updateRngAudioVolume);
     $('#rngMouseClickHoldTime').on('input change', updateTxtMouseClickHoldTime);
     $('#txtMouseClickHoldTime').change(updateRngMouseClickHoldTime);
+    $('#rngScrollWheelCooldown').on('input change', updateTxtScrollWheelCooldown);
+    $('#txtScrollWheelCooldown').change(updateRngScrollWheelCooldown);
     $('#chkAmbilightEnabled').parent().on('gumby.onChange', updateDivAmbilight);
     $('#rngAmbilightHaloSize').on('input change', updateTxtAmbilightHaloSize);
     $('#txtAmbilightHaloSize').change(updateRngAmbilightHaloSize);
@@ -885,5 +899,3 @@ function removeModifications() {
     $('[data-val0]').each(function() { delete $(this)[0].dataset.val0; });
     $('[data-val1]').each(function() { delete $(this)[0].dataset.val1; });
 }
-
-


### PR DESCRIPTION
Attempted fix for https://github.com/extesy/hoverzoom/issues/845

When I had a better look into this issue it seems like FireFox turns my single scroll into multiple smaller ones that each fire documentOnMouseWheel. I added a cooldown to the function so it will only accept 1 scroll event per 350ms. This fixes the issue for me 99% of the time.
 
Maybe this should be put behind an advanced setting rather than "live" for everyone. I think the cooldown amount of 350 could probably be lowered as well if you think this is too slow.