### PR TITLE
Fix catastrophic regex backtracking freezing amazon.com

### DIFF
--- a/plugins/amazon.js
+++ b/plugins/amazon.js
@@ -5,7 +5,7 @@ hoverZoomPlugins.push({
     prepareImgLinks:function (callback) {
         var res = [];
 
-        var reFullsize = /^(.*\/)([^\/.]+)\.[^\/.]+\.(gif|jpe?g|png)$/;
+        var reFullsize = /^(.*\/)([^\/]+)\.[^\/]+\.(gif|jpe?g|png)$/;
         var reReplace = '$1$2.$3';
 
         hoverZoom.urlReplace(res,

--- a/plugins/amazon.js
+++ b/plugins/amazon.js
@@ -5,8 +5,8 @@ hoverZoomPlugins.push({
     prepareImgLinks:function (callback) {
         var res = [];
 
-        var reFullsize = /(.*)\/(.*?)\.([^\/]*?)\.(gif|jpe?g|png)$/;
-        var reReplace = '$1/$2.$4';
+        var reFullsize = /^(.*\/)([^\/.]+)\.[^\/.]+\.(gif|jpe?g|png)$/;
+        var reReplace = '$1$2.$3';
 
         hoverZoom.urlReplace(res,
             'img[src]',


### PR DESCRIPTION
## Summary

Fixes #1770 — Hover Zoom+ freezes the logged-in amazon.com home page for 30+ seconds.

## Root cause

`plugins/amazon.js` used this regex to strip the "modifier" segment from Amazon image URLs:

```js
var reFullsize = /(.*)\/(.*?)\.([^\/]*?)\.(gif|jpe?g|png)$/;
```

The combination of a greedy `(.*)` followed by two lazy quantifiers with overlapping character classes (both `.*?` and `[^\/]*?` can match `.`) causes catastrophic backtracking on dot-heavy URLs. A Performance profile on logged-in amazon.com shows a single `RegExp` evaluation blocking the main thread for ~31.5 seconds.

This only reproduces on the logged-in home page because the personalized carousels feed dozens of lazy-loaded image URLs through this regex — some of which hit the pathological input shape. That matches why the maintainer couldn't reproduce it, and why others in the issue thread reported it working after the stall finally terminated.

## Fix

Rewrite the pattern with non-overlapping character classes and an anchor so it runs in linear time while preserving the same substitution:

```js
var reFullsize = /^(.*\/)([^\/.]+)\.[^\/.]+\.(gif|jpe?g|png)$/;
var reReplace = '$1$2.$3';
```

`.../71abc._AC_UL400_.jpg` → `.../71abc.jpg` (unchanged behavior).

## Test plan

- [x] Reload extension, open logged-in amazon.com home page — no stall.
- [x] Hover over product thumbnails on the home page — full-size popup works.
- [x] Hover over thumbnails on search results — works.
- [x] Hover over thumbnails on product detail page — works.
- [x] Attach before/after Performance profile screenshots in a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)