### PR TITLE
Added Citiv AI plugin to their new civitai.red domain

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2414,7 +2414,7 @@
         },
         {
             "js": ["plugins/civitai.js"],
-            "matches": ["*://*.civitai.com/*", "*://*.civitai.green/*"]
+            "matches": ["*://*.civitai.com/*", "*://*.civitai.green/*", "*://*.civitai.red/*"]
         },
         {
             "js": ["plugins/jike.js"],


### PR DESCRIPTION
HoverZoom didn't work on https://civitai.red, despite the fact that the site is identical in every way I could find. Turns out the issue was that the manifest file doesn't even try to enable the Civit AI plugin on https://civitai.red. So I fixed that.