### PR TITLE
Added Citiv AI plugin to their new civitai.red domain

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2414,7 +2414,7 @@
         },
         {
             "js": ["plugins/civitai.js"],
-            "matches": ["*://*.civitai.com/*", "*://*.civitai.green/*"]
+            "matches": ["*://*.civitai.com/*", "*://*.civitai.green/*", "*://*.civitai.red/*"]
         },
         {
             "js": ["plugins/jike.js"],


### PR DESCRIPTION
CivitAI opened a new offshoot site recently called https://civitai.red. This PR adds that domain to the CivitAI plugin.