### PR TITLE
New plugin: theguardian.com

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2465,6 +2465,10 @@
             "matches": ["*://*.sankaku.app/*"]
         },
         {
+            "js": ["plugins/theguardian.js"],
+            "matches": ["*://*.theguardian.com/*"]
+        },
+        {
             "js": ["plugins/vinted.js"],
             "matches": [
                 "*://*.vinted.com/*",

--- a/plugins/theguardian.js
+++ b/plugins/theguardian.js
@@ -1,0 +1,41 @@
+var hoverZoomPlugins = hoverZoomPlugins || [];
+hoverZoomPlugins.push({
+    name:'theguardian',
+    version:'0.1',
+    prepareImgLinks:function (callback) {
+        var res = [];
+        var old_width = /width=[0-9]*/;
+        var new_width = 'width=2000';
+
+        // This handles article thumbnails on the main page, and images
+        // inside articles.
+        $('a[href^="/"], a[href^="#img"], a[href*="theguardian.com"').one('mouseenter', function () {
+            var a = $(this);
+            var data = a.data();
+
+            if (data.hoverZoomSrc) {
+                return;
+            }
+
+            var img = a.parent().find('img[src*="i.guim.co.uk/"]');
+            var url = img.get(0).src;
+
+            data.hoverZoomSrc = [url.replace(old_width, new_width)];
+
+            a.addClass('hoverZoomLink');
+            hoverZoom.displayPicFromElement(a);
+        });
+
+        // This handles the profile picture of the article's author.
+        // The width parameter is necessary. It doesn't accept
+        // ridiculously large numbers, like 2100 and larger, but 2000
+        // seems fine.
+        hoverZoom.urlReplace(res,
+            'img[src*="i.guim.co.uk/"]',
+            old_width,
+            new_width,
+        );
+
+        callback($(res), this.name);
+    }
+});


### PR DESCRIPTION
Load thumbnails and the pictures inside articles.

This works, but there is a problem: it loads the thumbnail associated with a link when hovering anywhere inside the blue rectangle:

<img width="663" height="216" alt="Screenshot_20260528_222232" src="https://github.com/user-attachments/assets/6329bc32-c1fd-49fe-86cb-c7834dd4007a" />

I don't know how to make it load the thumbnail only when hovering over the thumbnail. I tried to select the ``<img>`` tags instead of ``<a>`` tags, but the mouseenter event doesn't fire.

This is why I'm making this a draft pull request. Maybe someone has a solution?