### PR TITLE
Threads: support video posts and overlay-wrapped media

### DIFF
--- a/plugins/threads.js
+++ b/plugins/threads.js
@@ -1,7 +1,7 @@
 var hoverZoomPlugins = hoverZoomPlugins || [];
 hoverZoomPlugins.push({
     name: 'Threads',
-    version: '0.3',
+    version: '0.5',
     prepareImgLinks: function (callback) {
         const name = this.name;
         var res = [];
@@ -35,6 +35,42 @@ hoverZoomPlugins.push({
                 link = img;
             }
             link.data().hoverZoomSrc = [this.src + '#hz'];
+            res.push(link[0]);
+        });
+
+        // Video posts autoplay an inline <video>; we zoom to its stream. currentSrc
+        // is usually a directly-playable progressive url; MSE blob: sources can't be
+        // reused so they're skipped. The ".video" suffix is the core's marker for a
+        // video stream.
+        //
+        // Threads lays a click/gesture overlay (div[role="presentation"]) over the
+        // video as a *sibling*, so that overlay — not the <video> — receives the
+        // hover, and the mousemove handler only looks at event.target's ancestors.
+        // The class therefore has to sit on the lowest common ancestor of the video
+        // and the overlay: climb the video's ancestors until one also contains that
+        // overlay. Falls back to the <video> itself.
+        $('video').each(function () {
+            var video = this;
+            var url = video.currentSrc || video.src;
+            if (!/^https?:/.test(url)) {
+                return;
+            }
+            var link = $(video);
+            for (var anc = video.parentElement, hops = 0; anc && hops < 15; anc = anc.parentElement, hops++) {
+                var overlays = anc.querySelectorAll('div[role="presentation"]');
+                var found = false;
+                for (var i = 0; i < overlays.length; i++) {
+                    if (!video.contains(overlays[i]) && !overlays[i].contains(video)) {
+                        found = true;
+                        break;
+                    }
+                }
+                if (found) {
+                    link = $(anc);
+                    break;
+                }
+            }
+            link.data().hoverZoomSrc = [url + '.video'];
             res.push(link[0]);
         });
 

--- a/plugins/threads.js
+++ b/plugins/threads.js
@@ -52,11 +52,14 @@ hoverZoomPlugins.push({
         $('video').each(function () {
             var video = this;
             var url = video.currentSrc || video.src;
-            if (!/^https?:/.test(url)) {
+            if (!url || !/^https?:/.test(url)) {
                 return;
             }
             var link = $(video);
-            for (var anc = video.parentElement, hops = 0; anc && hops < 15; anc = anc.parentElement, hops++) {
+            // The common ancestor is a handful of levels up (measured ~8 on a real
+            // post, in a small ~19-node media wrapper); cap the climb so a video with
+            // no nearby overlay doesn't walk up into the feed/body and scan it.
+            for (var anc = video.parentElement, hops = 0; anc && hops < 10; anc = anc.parentElement, hops++) {
                 var overlays = anc.querySelectorAll('div[role="presentation"]');
                 var found = false;
                 for (var i = 0; i < overlays.length; i++) {


### PR DESCRIPTION
Follow-up to #1785 (which added photo/carousel support and was merged quickly). This adds the remaining media types for the Threads plugin.

## Summary
- **Video posts**: zoom to the inline `<video>` stream via `currentSrc` (a directly-playable progressive MP4) using the core's `.video` marker; MSE `blob:` sources are skipped.
- **Overlay handling**: Threads lays a `div[role="presentation"]` click/gesture overlay over both photos and videos as a *sibling*, so the hover lands on the overlay rather than the media. Since the mousemove handler only matches `event.target` and its ancestors against `.hoverZoomLink`, the class is attached to the lowest common ancestor of the media and the overlay — the nearest clickable wrapper for photos, and the climbed overlay ancestor for videos. This lets inline carousels and videos zoom without opening the post first.

## Testing
- Verified on threads.com video posts (zoomed video plays with audio), single photos, and inline carousels (each slide zooms its own image).

Closes #1787

🤖 Generated with [Claude Code](https://claude.com/claude-code)