### PR TITLE
Threads: fix video zoom triggering on blank space around the video

### DIFF
--- a/plugins/threads.js
+++ b/plugins/threads.js
@@ -1,7 +1,7 @@
 var hoverZoomPlugins = hoverZoomPlugins || [];
 hoverZoomPlugins.push({
     name: 'Threads',
-    version: '0.5',
+    version: '0.6',
     prepareImgLinks: function (callback) {
         const name = this.name;
         var res = [];
@@ -61,25 +61,44 @@ hoverZoomPlugins.push({
             var link = $(video);
             var vb = video.getBoundingClientRect();
             if (vb.width && vb.height) {
-                for (var anc = video.parentElement, hops = 0; anc && hops < 10; anc = anc.parentElement, hops++) {
-                    var cands = anc.querySelectorAll('div[role="presentation"]');
-                    var overlay = null;
-                    for (var i = 0; i < cands.length; i++) {
-                        var c = cands[i];
-                        if (video.contains(c) || c.contains(video)) {
+                var coincides = function (b) {
+                    return Math.abs(b.left - vb.left) < 4 && Math.abs(b.top - vb.top) < 4 &&
+                        Math.abs(b.width - vb.width) < 4 && Math.abs(b.height - vb.height) < 4;
+                };
+                // The overlay lives in a sibling branch of the video's path, so climb
+                // the ancestors and look only at the branches we step past — never the
+                // path already walked and never re-querying a growing subtree, so each
+                // node is examined at most once. A sibling whose box doesn't even cover
+                // the video can't hold the (video-sized) overlay, so it's skipped
+                // without descending — this prunes unrelated siblings such as other
+                // feed posts. getBoundingClientRect then runs only on the few remaining
+                // presentation candidates.
+                var overlay = null;
+                for (var anc = video.parentElement, child = video, hops = 0;
+                     anc && hops < 10 && !overlay;
+                     child = anc, anc = anc.parentElement, hops++) {
+                    for (var i = 0; i < anc.children.length && !overlay; i++) {
+                        var sib = anc.children[i];
+                        if (sib === child) {
                             continue;
                         }
-                        var cb = c.getBoundingClientRect();
-                        if (Math.abs(cb.left - vb.left) < 4 && Math.abs(cb.top - vb.top) < 4 &&
-                            Math.abs(cb.width - vb.width) < 4 && Math.abs(cb.height - vb.height) < 4) {
-                            overlay = c;
-                            break;
+                        var sb = sib.getBoundingClientRect();
+                        if (sb.left > vb.left + 2 || sb.top > vb.top + 2 ||
+                            sb.right < vb.right - 2 || sb.bottom < vb.bottom - 2) {
+                            continue;
+                        }
+                        var cands = sib.matches('div[role="presentation"]') ? [sib]
+                            : sib.querySelectorAll('div[role="presentation"]');
+                        for (var j = 0; j < cands.length; j++) {
+                            if (coincides(cands[j].getBoundingClientRect())) {
+                                overlay = cands[j];
+                                break;
+                            }
                         }
                     }
-                    if (overlay) {
-                        link = $(overlay);
-                        break;
-                    }
+                }
+                if (overlay) {
+                    link = $(overlay);
                 }
             }
             link.data().hoverZoomSrc = [url + '.video'];

--- a/plugins/threads.js
+++ b/plugins/threads.js
@@ -44,11 +44,14 @@ hoverZoomPlugins.push({
         // video stream.
         //
         // Threads lays a click/gesture overlay (div[role="presentation"]) over the
-        // video as a *sibling*, so that overlay — not the <video> — receives the
-        // hover, and the mousemove handler only looks at event.target's ancestors.
-        // The class therefore has to sit on the lowest common ancestor of the video
-        // and the overlay: climb the video's ancestors until one also contains that
-        // overlay. Falls back to the <video> itself.
+        // video as a *sibling*, so the overlay — not the <video> — receives the hover
+        // (the mousemove handler only looks at event.target's ancestors). That overlay
+        // is sized exactly to the video, so attaching to it makes hovering the video
+        // fire while leaving the surrounding blank space inert. We identify it as the
+        // sibling-branch presentation div whose box coincides with the video's — a
+        // bare common-ancestor climb is unreliable, it can land on a wrapper larger
+        // than the video (which then zooms on blank space) or on an unrelated overlay.
+        // Falls back to the <video> itself.
         $('video').each(function () {
             var video = this;
             var url = video.currentSrc || video.src;
@@ -56,21 +59,27 @@ hoverZoomPlugins.push({
                 return;
             }
             var link = $(video);
-            // The common ancestor is a handful of levels up (measured ~8 on a real
-            // post, in a small ~19-node media wrapper); cap the climb so a video with
-            // no nearby overlay doesn't walk up into the feed/body and scan it.
-            for (var anc = video.parentElement, hops = 0; anc && hops < 10; anc = anc.parentElement, hops++) {
-                var overlays = anc.querySelectorAll('div[role="presentation"]');
-                var found = false;
-                for (var i = 0; i < overlays.length; i++) {
-                    if (!video.contains(overlays[i]) && !overlays[i].contains(video)) {
-                        found = true;
+            var vb = video.getBoundingClientRect();
+            if (vb.width && vb.height) {
+                for (var anc = video.parentElement, hops = 0; anc && hops < 10; anc = anc.parentElement, hops++) {
+                    var cands = anc.querySelectorAll('div[role="presentation"]');
+                    var overlay = null;
+                    for (var i = 0; i < cands.length; i++) {
+                        var c = cands[i];
+                        if (video.contains(c) || c.contains(video)) {
+                            continue;
+                        }
+                        var cb = c.getBoundingClientRect();
+                        if (Math.abs(cb.left - vb.left) < 4 && Math.abs(cb.top - vb.top) < 4 &&
+                            Math.abs(cb.width - vb.width) < 4 && Math.abs(cb.height - vb.height) < 4) {
+                            overlay = c;
+                            break;
+                        }
+                    }
+                    if (overlay) {
+                        link = $(overlay);
                         break;
                     }
-                }
-                if (found) {
-                    link = $(anc);
-                    break;
                 }
             }
             link.data().hoverZoomSrc = [url + '.video'];

--- a/plugins/threads.js
+++ b/plugins/threads.js
@@ -66,13 +66,12 @@ hoverZoomPlugins.push({
                         Math.abs(b.width - vb.width) < 4 && Math.abs(b.height - vb.height) < 4;
                 };
                 // The overlay lives in a sibling branch of the video's path, so climb
-                // the ancestors and look only at the branches we step past — never the
-                // path already walked and never re-querying a growing subtree, so each
-                // node is examined at most once. A sibling whose box doesn't even cover
-                // the video can't hold the (video-sized) overlay, so it's skipped
-                // without descending — this prunes unrelated siblings such as other
-                // feed posts. getBoundingClientRect then runs only on the few remaining
-                // presentation candidates.
+                // the ancestors and look only at the branches we step past (children
+                // other than the one we came up) — each node is examined at most once,
+                // never re-querying a subtree that grows as we climb. The overlay is
+                // absolutely positioned over the video, so its ancestors' boxes don't
+                // reflect its position; we match on the candidate's own box instead.
+                // getBoundingClientRect runs only on the presentation candidates.
                 var overlay = null;
                 for (var anc = video.parentElement, child = video, hops = 0;
                      anc && hops < 10 && !overlay;
@@ -80,11 +79,6 @@ hoverZoomPlugins.push({
                     for (var i = 0; i < anc.children.length && !overlay; i++) {
                         var sib = anc.children[i];
                         if (sib === child) {
-                            continue;
-                        }
-                        var sb = sib.getBoundingClientRect();
-                        if (sb.left > vb.left + 2 || sb.top > vb.top + 2 ||
-                            sb.right < vb.right - 2 || sb.bottom < vb.bottom - 2) {
                             continue;
                         }
                         var cands = sib.matches('div[role="presentation"]') ? [sib]


### PR DESCRIPTION
Follow-up to #1786. Fixes the video preview firing when hovering the blank space around a video.

## Cause
For videos the plugin attached `.hoverZoomLink` to the *common ancestor* of the `<video>` and its click overlay. That ancestor can be a wrapper larger than the video, so the core's `event.target`-ancestor match fires anywhere inside it — including the surrounding padding.

## Fix
Attach to the click overlay itself. Threads lays a `div[role="presentation"]` over the video sized **exactly** to it (verified: identical position and dimensions to the `<video>` box, and all sampled points over the video resolve to it). The plugin now selects the sibling-branch presentation div whose bounding box coincides with the video's and attaches there, so only the video area triggers. Falls back to the `<video>` element when no matching overlay is found — this also drops the unreliable bare common-ancestor climb that could land on an unrelated overlay.

## Testing
- Verified on a threads.com video post: hovering blank space no longer previews; hovering the video still zooms and plays; photos and carousels unaffected.

Closes #1788

🤖 Generated with [Claude Code](https://claude.com/claude-code)