### PR TITLE
Add video playback progress overlay

### DIFF
--- a/js/hoverzoom.js
+++ b/js/hoverzoom.js
@@ -324,6 +324,38 @@ var hoverZoom = {
                 'overflow':'hidden',
                 'vertical-align':'top',
                 'horizontal-align':'right'
+            },
+            hzPlaybackProgressCss = {
+                'position':'absolute',
+                'z-index':'2147483647',
+                'left':'8px',
+                'right':'8px',
+                'bottom':'8px',
+                'height':'14px',
+                'border-radius':'7px',
+                'background':'rgba(0, 0, 0, 0.55)',
+                'box-shadow':'0 1px 3px rgba(0, 0, 0, 0.65)',
+                'overflow':'hidden',
+                'pointer-events':'none'
+            },
+            hzPlaybackProgressFillCss = {
+                'width':'0%',
+                'height':'100%',
+                'background':'rgba(255, 122, 24, 0.9)'
+            },
+            hzPlaybackProgressTimeCss = {
+                'position':'absolute',
+                'left':'0',
+                'right':'0',
+                'top':'0',
+                'height':'14px',
+                'line-height':'14px',
+                'font':'menu',
+                'font-size':'10px',
+                'font-weight':'bold',
+                'color':'white',
+                'text-align':'center',
+                'text-shadow':'1px 1px 2px black'
             };
 
         // needed to flip text tracks on videos
@@ -1936,6 +1968,49 @@ var hoverZoom = {
             $(msgDiv).appendTo(hz.hzViewer.hzContainer);
         }
 
+        function formatPlaybackTime(seconds) {
+            seconds = Math.max(0, Math.floor(seconds || 0));
+            let hours = Math.floor(seconds / 3600);
+            let minutes = Math.floor((seconds - hours * 3600) / 60);
+            let secs = seconds % 60;
+
+            if (hours > 0) {
+                return hours + ':' + String(minutes).padStart(2, '0') + ':' + String(secs).padStart(2, '0');
+            }
+            return minutes + ':' + String(secs).padStart(2, '0');
+        }
+
+        function addPlaybackProgress(video) {
+            $('#hzPlaybackProgress').remove();
+
+            let progress = $('<div/>', {id:'hzPlaybackProgress'}).css(hzPlaybackProgressCss).hide();
+            let fill = $('<div/>', {id:'hzPlaybackProgressFill'}).css(hzPlaybackProgressFillCss).appendTo(progress);
+            let time = $('<div/>', {id:'hzPlaybackProgressTime'}).css(hzPlaybackProgressTimeCss).appendTo(progress);
+            progress.appendTo(hz.hzViewer.hzContainer);
+
+            function updatePlaybackProgress() {
+                let duration = video.duration;
+                if (!isFinite(duration) || duration <= 0) {
+                    progress.hide();
+                    return;
+                }
+
+                let currentTime = Math.min(Math.max(video.currentTime || 0, 0), duration);
+                let percent = currentTime / duration * 100;
+                fill.css('width', percent.toFixed(2) + '%');
+                time.text(formatPlaybackTime(currentTime) + ' / ' + formatPlaybackTime(duration));
+                progress.show();
+            }
+
+            video.addEventListener('loadedmetadata', updatePlaybackProgress);
+            video.addEventListener('durationchange', updatePlaybackProgress);
+            video.addEventListener('timeupdate', updatePlaybackProgress);
+            video.addEventListener('seeked', updatePlaybackProgress);
+            video.addEventListener('play', updatePlaybackProgress);
+            video.addEventListener('pause', updatePlaybackProgress);
+            updatePlaybackProgress();
+        }
+
         function displayFullSizeImage() {
             cLog('displayFullSizeImage');
 
@@ -1997,6 +2072,8 @@ var hoverZoom = {
             // - display also audio controls if needed (distinct sources for audio & video)
             let video = hz.hzViewer.find('video')[0];
             if (video) {
+                addPlaybackProgress(video);
+
                 let audio = null;
                 if (audioControls)
                     audio = audioControls[0];

--- a/js/hoverzoom.js
+++ b/js/hoverzoom.js
@@ -1983,6 +1983,15 @@ var hoverZoom = {
         function addPlaybackProgress(video) {
             $('#hzPlaybackProgress').remove();
 
+            if (video.hzUpdatePlaybackProgress) {
+                video.removeEventListener('loadedmetadata', video.hzUpdatePlaybackProgress);
+                video.removeEventListener('durationchange', video.hzUpdatePlaybackProgress);
+                video.removeEventListener('timeupdate', video.hzUpdatePlaybackProgress);
+                video.removeEventListener('seeked', video.hzUpdatePlaybackProgress);
+                video.removeEventListener('play', video.hzUpdatePlaybackProgress);
+                video.removeEventListener('pause', video.hzUpdatePlaybackProgress);
+            }
+
             let progress = $('<div/>', {id:'hzPlaybackProgress'}).css(hzPlaybackProgressCss).hide();
             let fill = $('<div/>', {id:'hzPlaybackProgressFill'}).css(hzPlaybackProgressFillCss).appendTo(progress);
             let time = $('<div/>', {id:'hzPlaybackProgressTime'}).css(hzPlaybackProgressTimeCss).appendTo(progress);
@@ -2002,6 +2011,7 @@ var hoverZoom = {
                 progress.show();
             }
 
+            video.hzUpdatePlaybackProgress = updatePlaybackProgress;
             video.addEventListener('loadedmetadata', updatePlaybackProgress);
             video.addEventListener('durationchange', updatePlaybackProgress);
             video.addEventListener('timeupdate', updatePlaybackProgress);

--- a/js/hoverzoom.js
+++ b/js/hoverzoom.js
@@ -1999,7 +1999,7 @@ var hoverZoom = {
 
             function updatePlaybackProgress() {
                 let duration = video.duration;
-                if (!isFinite(duration) || duration <= 0) {
+                if (!isFinite(duration) || duration <= 0 || viewerLocked) {
                     progress.hide();
                     return;
                 }


### PR DESCRIPTION
## Summary
- Add a bottom overlay progress bar for zoomed videos
- Show elapsed and total playback time when media duration is available
- Hide the progress overlay for streams/media without a finite duration
- Remove previously registered playback progress listeners before attaching replacements

## Review follow-up
This supersedes #1790 and addresses the duplicate-listener and stale-closure issue raised in [the review thread](https://github.com/extesy/hoverzoom/pull/1790#discussion_r3455070945).

## Validation
- `node --check js/hoverzoom.js`
- `git diff --check origin/master...HEAD`
- Targeted mocked-video regression check: calling `addPlaybackProgress(video)` twice leaves one current listener for each playback event and removes the stale callbacks
